### PR TITLE
DATAGO-80652: Allow workflows to release all the way to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
When release workflow is run, this change makes it so it is added to the main central repository without further interaction.