### PR TITLE
DATAGO-85722: Input whitesource project name

### DIFF
--- a/.github/workflows/build-java-binder.yaml
+++ b/.github/workflows/build-java-binder.yaml
@@ -236,4 +236,5 @@ jobs:
         with:
           whitesource_api_key: ${{ steps.secrets.outputs.WHITESOURCE_API_KEY }}
           whitesource_product_name: ${{ inputs.whitesource_product_name }}
+          whitesource_project_name: "${{ github.event.repository.name }}"
           target_directory: "target/lib"


### PR DESCRIPTION
Since this project has its own workflow for build-java-binder, the whitesource scan needs to be imitated properly to reflect it's parallel in maas build actions: https://github.com/SolaceDev/maas-build-actions/blob/53de1371fd9535acad74d643dea0c233d40ad456/.github/workflows/build-java-binder.yaml#L176