### PR TITLE
DATAGO-83635: Support for publishing spark connector to products solace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         default: 'main'
 jobs:
   release_binder:
-    uses: SolaceDev/maas-build-actions/.github/workflows/release-binders-external.yaml@spark-connector-products
+    uses: SolaceDev/maas-build-actions/.github/workflows/release-binders-external.yaml@master
     with:
       main_branch: "${{ github.event.inputs.release_branch}}"
       push_external: ${{ github.event.inputs.release_central == 'true'}}
@@ -86,7 +86,7 @@ jobs:
           ls -l $GITHUB_WORKSPACE/release_artifacts
 
       - name: Push Artifacts to products.solace.com
-        uses: SolaceDev/maas-build-actions/.github/actions/transfer-files-products-solace@spark-connector-products
+        uses: SolaceDev/maas-build-actions/.github/actions/transfer-files-products-solace@master
         with:
           artifact_directory: "${{ github.workspace }}/release_artifacts"
           version: ${{ github.event.inputs.release_version }}


### PR DESCRIPTION
* Adding steps to publish spark artifacts to products solace
* Didn't do it in the shareable workflow since the artifacts seem unique here and not every binder may follow this format
