### PR TITLE
DATAGO-92757: Update github actions versions

### DIFF
--- a/.github/workflows/build-java-binder.yaml
+++ b/.github/workflows/build-java-binder.yaml
@@ -50,7 +50,7 @@ jobs:
       VAULT_ADDR: https://vault.maas-vault-prod.solace.cloud:8200
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Uploading Artifacts - SpotBugs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Code Analysis Results - SpotBugs
           path: |
@@ -199,7 +199,7 @@ jobs:
 
       - name: Uploading Artifacts - Unit/Integration Tests
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results - Unit-Integration Tests
           path: |


### PR DESCRIPTION
Update to newer actions versions to stop failing jobs