### PR TITLE
DATAGO-118237: Fix timestamp when publishing to Solace

### DIFF
--- a/src/main/java/com/solacecoe/connectors/spark/streaming/partitions/SolaceInputPartitionReader.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/partitions/SolaceInputPartitionReader.java
@@ -167,7 +167,7 @@ public class SolaceInputPartitionReader implements PartitionReader<InternalRow>,
             SolaceRecord solaceRecord = SolaceRecord.getMapper(this.properties.getOrDefault(SolaceSparkStreamingProperties.OFFSET_INDICATOR, SolaceSparkStreamingProperties.OFFSET_INDICATOR_DEFAULT)).map(solaceMessage.bytesXMLMessage);
             long timestamp = solaceRecord.getSenderTimestamp();
             if (solaceRecord.getSenderTimestamp() == 0) {
-                timestamp = System.currentTimeMillis() / 1000;
+                timestamp = System.currentTimeMillis();
             }
             InternalRow row;
             if (this.includeHeaders) {

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
@@ -420,6 +420,8 @@ public class SolaceBroker implements Serializable {
         xmlMessage.setCorrelationId(applicationMessageId);
         xmlMessage.setApplicationMessageId(applicationMessageId);
         if (timestamp > 0L) {
+            // Spark TimestampType by default return's in microseconds(https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/types/TimestampType.html) whether it is millis or seconds. So division by 1000 is required
+            // as microseconds format will be too long to parse
             long senderTimestamp = timestamp/1000;
             xmlMessage.setSenderTimestamp(senderTimestamp);
         }

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
@@ -420,7 +420,8 @@ public class SolaceBroker implements Serializable {
         xmlMessage.setCorrelationId(applicationMessageId);
         xmlMessage.setApplicationMessageId(applicationMessageId);
         if (timestamp > 0L) {
-            xmlMessage.setSenderTimestamp(timestamp / 1000);
+            long senderTimestamp = timestamp/1000;
+            xmlMessage.setSenderTimestamp(senderTimestamp);
         }
         xmlMessage.setDeliveryMode(DeliveryMode.PERSISTENT);
 

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
@@ -420,7 +420,7 @@ public class SolaceBroker implements Serializable {
         xmlMessage.setCorrelationId(applicationMessageId);
         xmlMessage.setApplicationMessageId(applicationMessageId);
         if (timestamp > 0L) {
-            xmlMessage.setSenderTimestamp(timestamp);
+            xmlMessage.setSenderTimestamp(timestamp / 1000);
         }
         xmlMessage.setDeliveryMode(DeliveryMode.PERSISTENT);
 

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
@@ -83,6 +83,7 @@ public class SolaceDataWriter implements DataWriter<InternalRow>, Serializable {
         }
         long timestamp = 0L;
         if(projectedRow.get(4, DataTypes.TimestampType) != null) {
+            // TimestampType always returns long. So safe to use getLong
             timestamp = projectedRow.getLong(4);
         }
         UnsafeMapData headersMap = new UnsafeMapData();

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
@@ -83,7 +83,7 @@ public class SolaceDataWriter implements DataWriter<InternalRow>, Serializable {
         }
         long timestamp = 0L;
         if(projectedRow.get(4, DataTypes.TimestampType) != null) {
-            timestamp = Long.parseLong(projectedRow.get(4, DataTypes.TimestampType).toString());
+            timestamp = projectedRow.getLong(4);
         }
         UnsafeMapData headersMap = new UnsafeMapData();
         if(projectedRow.numFields() > 5 && projectedRow.getMap(5) != null) {

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -7,6 +7,7 @@ import com.solace.semp.v2.config.client.model.MsgVpnQueueSubscription;
 import com.solacecoe.connectors.spark.base.SempV2Api;
 import com.solacecoe.connectors.spark.base.SolaceSession;
 import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkStreamingProperties;
+import com.solacecoe.connectors.spark.streaming.solace.SolaceConnectionManager;
 import com.solacesystems.jcsmp.*;
 import org.apache.spark.api.java.function.VoidFunction2;
 import org.apache.spark.sql.Dataset;
@@ -146,6 +147,8 @@ public class SolaceSparkStreamingSinkIT {
         if(Files.exists(path2)) {
             FileUtils.deleteDirectory(path2.toAbsolutePath().toFile());
         }
+
+        SolaceConnectionManager.closeAllConnections();
     }
 
     @Test
@@ -806,7 +809,7 @@ public class SolaceSparkStreamingSinkIT {
     }
 
     @Test
-    @Order(13)
+    @Order(16)
     void Should_Not_ProcessData_When_QueueIsEmpty() throws TimeoutException, InterruptedException {
         Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
         final long[] batchTriggerCount = {0};
@@ -866,7 +869,7 @@ public class SolaceSparkStreamingSinkIT {
     }
 
     @Test
-    @Order(14)
+    @Order(13)
     void Should_ProcessData_Publish_MicrosAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
         Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
         DataStreamReader reader = sparkSession.readStream()
@@ -920,7 +923,7 @@ public class SolaceSparkStreamingSinkIT {
     }
 
     @Test
-    @Order(15)
+    @Order(14)
     void Should_ProcessData_And_Publish_MillisAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
         Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
         DataStreamReader reader = sparkSession.readStream()
@@ -975,7 +978,7 @@ public class SolaceSparkStreamingSinkIT {
     }
 
     @Test
-    @Order(16)
+    @Order(15)
     void Should_ProcessData_And_Publish_SecondsAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
         Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
         DataStreamReader reader = sparkSession.readStream()

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -16,6 +16,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.streaming.DataStreamReader;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
+import static org.apache.spark.sql.functions.*;
 import org.junit.jupiter.api.*;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
@@ -860,6 +861,170 @@ public class SolaceSparkStreamingSinkIT {
         }
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(1L, batchTriggerCount[0]));
+        Thread.sleep(3000); // add timeout to ack messages on queue
+        streamingQuery.stop();
+    }
+
+    @Test
+    @Order(14)
+    void Should_ProcessData_Publish_MicrosAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
+        Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
+        DataStreamReader reader = sparkSession.readStream()
+                .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                .option(SolaceSparkStreamingProperties.QUEUE, "Solace/Queue/0")
+                .option(SolaceSparkStreamingProperties.BATCH_SIZE, "50")
+                .option("checkpointLocation", path.toAbsolutePath().toString())
+                .format("solace");
+        final long[] count = {0};
+        Dataset<Row> dataset = reader.load();
+        StreamingQuery streamingQuery = dataset.writeStream().foreachBatch((VoidFunction2<Dataset<Row>, Long>) (dataset1, batchId) -> {
+            dataset1.write()
+                    .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                    .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                    .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                    .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                    .option(SolaceSparkStreamingProperties.BATCH_SIZE, 0)
+                    .option(SolaceSparkStreamingProperties.TOPIC, "random/topic")
+                    .mode(SaveMode.Append)
+                    .format("solace").save();
+        }).start();
+
+        SolaceSession session = new SolaceSession(solaceContainer.getOrigin(Service.SMF), solaceContainer.getVpn(), solaceContainer.getUsername(), solaceContainer.getPassword());
+        Topic topic = JCSMPFactory.onlyInstance().createTopic("random/topic");
+        XMLMessageConsumer messageConsumer = null;
+        try {
+            messageConsumer = session.getSession().getMessageConsumer(new XMLMessageListener() {
+                @Override
+                public void onReceive(BytesXMLMessage bytesXMLMessage) {
+                    count[0] = count[0] + 1;
+                }
+
+                @Override
+                public void onException(JCSMPException e) {
+                    // Not required for test
+
+                }
+            });
+            session.getSession().addSubscription(topic);
+            messageConsumer.start();
+        } catch (JCSMPException e) {
+            throw new RuntimeException(e);
+        }
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Thread.sleep(3000); // add timeout to ack messages on queue
+        streamingQuery.stop();
+    }
+
+    @Test
+    @Order(15)
+    void Should_ProcessData_And_Publish_MillisAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
+        Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
+        DataStreamReader reader = sparkSession.readStream()
+                .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                .option(SolaceSparkStreamingProperties.QUEUE, "Solace/Queue/0")
+                .option(SolaceSparkStreamingProperties.BATCH_SIZE, "50")
+                .option("checkpointLocation", path.toAbsolutePath().toString())
+                .format("solace");
+        final long[] count = {0};
+        Dataset<Row> dataset = reader.load();
+        StreamingQuery streamingQuery = dataset.writeStream().foreachBatch((VoidFunction2<Dataset<Row>, Long>) (dataset1, batchId) -> {
+            dataset1.withColumn("TimeStamp", unix_millis(current_timestamp()));
+            dataset1.write()
+                    .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                    .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                    .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                    .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                    .option(SolaceSparkStreamingProperties.BATCH_SIZE, 0)
+                    .option(SolaceSparkStreamingProperties.TOPIC, "random/topic")
+                    .mode(SaveMode.Append)
+                    .format("solace").save();
+        }).start();
+
+        SolaceSession session = new SolaceSession(solaceContainer.getOrigin(Service.SMF), solaceContainer.getVpn(), solaceContainer.getUsername(), solaceContainer.getPassword());
+        Topic topic = JCSMPFactory.onlyInstance().createTopic("random/topic");
+        XMLMessageConsumer messageConsumer = null;
+        try {
+            messageConsumer = session.getSession().getMessageConsumer(new XMLMessageListener() {
+                @Override
+                public void onReceive(BytesXMLMessage bytesXMLMessage) {
+                    count[0] = count[0] + 1;
+                }
+
+                @Override
+                public void onException(JCSMPException e) {
+                    // Not required for test
+
+                }
+            });
+            session.getSession().addSubscription(topic);
+            messageConsumer.start();
+        } catch (JCSMPException e) {
+            throw new RuntimeException(e);
+        }
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Thread.sleep(3000); // add timeout to ack messages on queue
+        streamingQuery.stop();
+    }
+
+    @Test
+    @Order(16)
+    void Should_ProcessData_And_Publish_SecondsAs_SenderTimeStamp_To_Solace() throws TimeoutException, InterruptedException {
+        Path path = Paths.get("src", "test", "resources", "spark-checkpoint-1");
+        DataStreamReader reader = sparkSession.readStream()
+                .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                .option(SolaceSparkStreamingProperties.QUEUE, "Solace/Queue/0")
+                .option(SolaceSparkStreamingProperties.BATCH_SIZE, "50")
+                .option("checkpointLocation", path.toAbsolutePath().toString())
+                .format("solace");
+        final long[] count = {0};
+        Dataset<Row> dataset = reader.load();
+        StreamingQuery streamingQuery = dataset.writeStream().foreachBatch((VoidFunction2<Dataset<Row>, Long>) (dataset1, batchId) -> {
+            dataset1.withColumn( "TimeStamp", unix_seconds(current_timestamp()));
+            dataset1.write()
+                    .option(SolaceSparkStreamingProperties.HOST, solaceContainer.getOrigin(Service.SMF))
+                    .option(SolaceSparkStreamingProperties.VPN, solaceContainer.getVpn())
+                    .option(SolaceSparkStreamingProperties.USERNAME, solaceContainer.getUsername())
+                    .option(SolaceSparkStreamingProperties.PASSWORD, solaceContainer.getPassword())
+                    .option(SolaceSparkStreamingProperties.BATCH_SIZE, 0)
+                    .option(SolaceSparkStreamingProperties.TOPIC, "random/topic")
+                    .mode(SaveMode.Append)
+                    .format("solace").save();
+        }).start();
+
+        SolaceSession session = new SolaceSession(solaceContainer.getOrigin(Service.SMF), solaceContainer.getVpn(), solaceContainer.getUsername(), solaceContainer.getPassword());
+        Topic topic = JCSMPFactory.onlyInstance().createTopic("random/topic");
+        XMLMessageConsumer messageConsumer = null;
+        try {
+            messageConsumer = session.getSession().getMessageConsumer(new XMLMessageListener() {
+                @Override
+                public void onReceive(BytesXMLMessage bytesXMLMessage) {
+                    count[0] = count[0] + 1;
+                }
+
+                @Override
+                public void onException(JCSMPException e) {
+                    // Not required for test
+
+                }
+            });
+            session.getSession().addSubscription(topic);
+            messageConsumer.start();
+        } catch (JCSMPException e) {
+            throw new RuntimeException(e);
+        }
+
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
         Thread.sleep(3000); // add timeout to ack messages on queue
         streamingQuery.stop();
     }


### PR DESCRIPTION
Spark returns timestamp in micro seconds, which will cause timestamp parsing issues. Hence fixing it when publishing rather at consumption.