### PR TITLE
ci(DATAGO-122643):Add FOSSA scanning with automated CI/CD workflows

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -8,6 +8,7 @@ project:
   labels:
     - MI
     - repository
+    - techcoe
 
 vendoredDependencies:
   forceRescans: false

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,34 @@
+version: 3
+
+project:
+  locator: SolaceProducts_pubsubplus-connector-spark
+  id: SolaceProducts_pubsubplus-connector-spark
+  name: pubsubplus-connector-spark
+  teams: []
+  labels:
+    - MI
+    - repository
+
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+      - "./target"
+      - "./src/test"
+      - "./samples"
+      - "./src/docs"
+
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+    - ./target
+    - ./src/test
+    - ./samples
+    - ./src/docs
+
+telemetry:
+  scope: full

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -12,7 +12,7 @@
       },
       "project_id": "SolaceProducts_pubsubplus-connector-spark",
       "team": null,
-      "labels": ["MI", "repository", "connectors-coe"]
+      "labels": [""]
     }
   },
   "build": {

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,25 @@
+{
+  "sca_scanning": {
+    "enabled": true,
+    "fossa": {
+      "policy": {
+        "mode": "REPORT",
+        "block_on": ["policy_conflict", "unlicensed_dependency"]
+      },
+      "vulnerability": {
+        "mode": "REPORT",
+        "block_on": ["critical", "high"]
+      },
+      "project_id": "SolaceProducts_pubsubplus-connector-spark",
+      "team": null,
+      "labels": ["MI", "repository", "connectors-coe"]
+    }
+  },
+  "build": {
+    "squad": "connectors-coe",
+    "service_name": "pubsubplus-connector-spark",
+    "java_environment": "zulu",
+    "jre_version": "17",
+    "runner_label": "ubuntu-22.04"
+  }
+}

--- a/.github/workflows/build-integrationtest.yaml
+++ b/.github/workflows/build-integrationtest.yaml
@@ -49,14 +49,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieve secrets from Vault
         id: secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         continue-on-error: true
         with:
           url: "${{ secrets.VAULT_ADDR }}"
@@ -73,7 +73,7 @@ jobs:
         run: echo "Could not (${{steps.secrets.outcome}}) log into vault using cicd-workflows-secret-read-role. Has this repo been onboarded in maas-vault-configuration?"; exit 1
 
       - name: Set up JDK ${{ inputs.jre_version }} (${{inputs.java_environment}})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: ${{ inputs.java_environment }}
           java-version: ${{ inputs.jre_version }}
@@ -103,7 +103,7 @@ jobs:
         run: mvn -B compile process-classes pmd:aggregate-pmd-check spotbugs:check  --settings "${GITHUB_WORKSPACE}/maven/settings.xml"
 
       - name: Unit/Integration Tests JDK 8 (zulu)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: zulu
           java-version: 8
@@ -120,7 +120,7 @@ jobs:
           --settings "${GITHUB_WORKSPACE}/maven/settings.xml"
 
       - name: Reset JDK to ${{ inputs.jre_version }} (${{inputs.java_environment}})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: ${{ inputs.java_environment }}
           java-version: ${{ inputs.jre_version }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Uploading Artifacts - PMD
         if: always()
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: Code Analysis Results - PMD
           path: |
@@ -147,13 +147,13 @@ jobs:
       - name: Uploading SARIF file - PMD
         if: ${{ !cancelled() && inputs.github_advanced_security_scanning_enabled == 'true' }}
         continue-on-error: true # Likely failed because repo doesn't have GitHub Enhanced Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           sarif_file: ${{ github.workspace }}/target/pmd.sarif.json
 
       - name: Uploading Artifacts - SpotBugs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Code Analysis Results - SpotBugs
           path: |
@@ -164,7 +164,7 @@ jobs:
       - name: Uploading SARIF file - SpotBugs
         if: ${{ !cancelled() && inputs.github_advanced_security_scanning_enabled == 'true'}}
         continue-on-error: true # Likely failed because repo doesn't have GitHub Enhanced Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           sarif_file: ${{ github.workspace }}/**/target/spotbugsSarif.json
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Uploading Artifacts - Unit/Integration Tests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Test Results - Unit-Integration Tests
           path: |
@@ -188,12 +188,12 @@ jobs:
       - name: Publishing Test Results - Unit/Integration Tests Pre-Condition
         if: ${{ always() && inputs.unit_integration_test_reports != '' }}
         id: unit_integration_test_report_exists
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2.0.0
         with:
           files: "${{inputs.unit_integration_test_reports}}"
 
       - name: Publishing Test Results - Unit/Integration Tests
-        uses: dorny/test-reporter@v1.7.0
+        uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4 # v1.7.0
         if: ${{ always() && inputs.unit_integration_test_reports != '' && steps.unit_integration_test_report_exists.outputs.files_exists == 'true' }}
         with:
           name: Unit-Integration Tests

--- a/.github/workflows/build-java-binder.yaml
+++ b/.github/workflows/build-java-binder.yaml
@@ -49,14 +49,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieve secrets from Vault
         id: secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         continue-on-error: true
         with:
           url: "${{ secrets.VAULT_ADDR }}"
@@ -76,7 +76,7 @@ jobs:
         run: echo "Could not (${{steps.secrets.outcome}}) log into vault using cicd-workflows-secret-read-role. Has this repo been onboarded in maas-vault-configuration?"; exit 1
 
       - name: Set up JDK ${{ inputs.jre_version }} (${{inputs.java_environment}})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: ${{ inputs.java_environment }}
           java-version: ${{ inputs.jre_version }}
@@ -107,7 +107,7 @@ jobs:
         run: mvn -B compile process-classes pmd:aggregate-pmd-check spotbugs:check  --settings "${GITHUB_WORKSPACE}/maven/settings.xml"
 
       - name: Unit/Integration Tests JDK 8 (zulu)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: zulu
           java-version: 8
@@ -122,7 +122,7 @@ jobs:
           --settings "${GITHUB_WORKSPACE}/maven/settings.xml"
 
       - name: Reset JDK to ${{ inputs.jre_version }} (${{inputs.java_environment}})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: ${{ inputs.java_environment }}
           java-version: ${{ inputs.jre_version }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Uploading Artifacts - PMD
         if: always()
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: Code Analysis Results - PMD
           path: |
@@ -172,13 +172,13 @@ jobs:
       - name: Uploading SARIF file - PMD
         if: ${{ !cancelled() && inputs.github_advanced_security_scanning_enabled == 'true' }}
         continue-on-error: true # Likely failed because repo doesn't have GitHub Enhanced Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           sarif_file: ${{ github.workspace }}/target/pmd.sarif.json
 
       - name: Uploading Artifacts - SpotBugs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Code Analysis Results - SpotBugs
           path: |
@@ -189,7 +189,7 @@ jobs:
       - name: Uploading SARIF file - SpotBugs
         if: ${{ !cancelled() && inputs.github_advanced_security_scanning_enabled == 'true'}}
         continue-on-error: true # Likely failed because repo doesn't have GitHub Enhanced Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           sarif_file: ${{ github.workspace }}/**/target/spotbugsSarif.json
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: Uploading Artifacts - Unit/Integration Tests
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Test Results - Unit-Integration Tests
           path: |
@@ -213,12 +213,12 @@ jobs:
       - name: Publishing Test Results - Unit/Integration Tests Pre-Condition
         if: ${{ always() && inputs.unit_integration_test_reports != '' }}
         id: unit_integration_test_report_exists
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2.0.0
         with:
           files: "${{inputs.unit_integration_test_reports}}"
 
       - name: Publishing Test Results - Unit/Integration Tests
-        uses: dorny/test-reporter@v1.7.0
+        uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4 # v1.7.0
         if: ${{ always() && inputs.unit_integration_test_reports != '' && steps.unit_integration_test_report_exists.outputs.files_exists == 'true' }}
         with:
           name: Unit-Integration Tests

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -1,0 +1,36 @@
+name: CI - Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read        # For checkout
+  pull-requests: write  # For PR comments
+  actions: read         # For sca-scan-and-guard
+  issues: write         # For PR comments
+  checks: write         # For FOSSA status checks
+  statuses: write       # For FOSSA commit status
+  packages: write       # For build workflows
+  id-token: write       # For Vault auth in build workflows
+
+jobs:
+  fossa_scan:
+    name: FOSSA Scan
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      use_vault: false
+      config_file: '.github/workflow-config.json'
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  build_jar:
+    name: Build / Test / Analyze
+    uses: ./.github/workflows/build-integrationtest.yaml
+    with:
+      unit_integration_test_reports: "**/target/failsafe-reports/**/TEST*.xml"
+    secrets: inherit

--- a/.github/workflows/fossa-scan.yaml
+++ b/.github/workflows/fossa-scan.yaml
@@ -1,0 +1,28 @@
+name: Manual FOSSA Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to scan (default: current branch)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+  issues: write
+  checks: write
+  statuses: write
+
+jobs:
+  fossa_scan:
+    name: FOSSA Scan
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      git_ref: ${{ inputs.branch }}
+      use_vault: false
+      config_file: '.github/workflow-config.json'
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,14 +92,14 @@ jobs:
       java_environment: zulu
       jre_version: 17
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.release_branch }}
           fetch-depth: 0
           ssh-key: ${{ secrets.COMMIT_KEY }}
       - name: Retrieve secrets from Vault
         id: secrets
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         continue-on-error: true
         with:
           url: "${{ secrets.VAULT_ADDR }}"
@@ -122,7 +122,7 @@ jobs:
 
       # Setup all secrets and env needed for the build
       - name: Set up JDK ${{ env.jre_version }} (${{env.java_environment}})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: ${{ env.java_environment }}
           java-version: ${{ env.jre_version }}
@@ -135,7 +135,7 @@ jobs:
           passphrase: ${{ steps.secrets.outputs.MAVEN_GPG_KEY_PASSPHRASE }}
 
       - name: Add SSH Key for write access for commits
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
+        uses: kielabokkie/ssh-key-and-known-hosts-action@242f53d26bbd43e843b08b0cbc8287ceb03fbe71 # v1.5.0
         with:
           ssh-private-key: ${{ secrets.COMMIT_KEY }}
           ssh-host: github.com
@@ -208,7 +208,7 @@ jobs:
           mvn scm:tag -B -Dtag=${{ inputs.release_version }}
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
           tag: "${{ inputs.release_version }}"
           generateReleaseNotes: true
@@ -230,7 +230,7 @@ jobs:
           -Dmessage="[ci skip] prepare for next development iteration"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,41 @@ on:
           - Beta
           - EA
           - GA
+      skip_fossa:
+        description: "Skip FOSSA scan (admin bypass only - use if FOSSA site is down)"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  pull-requests: write
+  actions: read
+  issues: write
+  checks: write
+  statuses: write
+
 jobs:
+  fossa_scan:
+    name: FOSSA Scan
+    if: inputs.skip_fossa == false
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      git_ref: ${{ inputs.release_version }}
+      use_vault: false
+      config_file: '.github/workflow-config.json'
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
   release_binder:
+    needs: [fossa_scan]
+    if: always() && (needs.fossa_scan.result == 'success' || needs.fossa_scan.result == 'skipped')
     runs-on: ubuntu-latest
     env:
       java_environment: zulu
       jre_version: 17
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,40 @@ permissions:
   statuses: write
 
 jobs:
+  check_admin:
+    name: Check Admin Permissions
+    runs-on: ubuntu-latest
+    if: inputs.skip_fossa == true
+    outputs:
+      is_admin: ${{ steps.check.outputs.is_admin }}
+    steps:
+      - name: Check if user is admin
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          USER="${{ github.actor }}"
+          REPO="${{ github.repository }}"
+
+          # Get user's permission level
+          PERMISSION=$(gh api repos/$REPO/collaborators/$USER/permission --jq '.permission')
+
+          echo "User: $USER"
+          echo "Permission: $PERMISSION"
+
+          if [[ "$PERMISSION" == "admin" ]]; then
+            echo "is_admin=true" >> $GITHUB_OUTPUT
+            echo "✅ User $USER has admin permissions - bypass allowed"
+          else
+            echo "is_admin=false" >> $GITHUB_OUTPUT
+            echo "❌ User $USER does not have admin permissions - bypass NOT allowed"
+            exit 1
+          fi
+
   fossa_scan:
     name: FOSSA Scan
-    if: inputs.skip_fossa == false
+    needs: [check_admin]
+    if: always() && inputs.skip_fossa == false
     uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
     with:
       git_ref: ${{ inputs.release_version }}
@@ -54,8 +85,8 @@ jobs:
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
   release_binder:
-    needs: [fossa_scan]
-    if: always() && (needs.fossa_scan.result == 'success' || needs.fossa_scan.result == 'skipped')
+    needs: [check_admin, fossa_scan]
+    if: always() && (needs.fossa_scan.result == 'success' || (needs.fossa_scan.result == 'skipped' && needs.check_admin.outputs.is_admin == 'true'))
     runs-on: ubuntu-latest
     env:
       java_environment: zulu


### PR DESCRIPTION
## Summary

This PR adds complete FOSSA security and license compliance scanning to the repository with automated CI/CD integration.

## Configuration Files

- **`.fossa.yml`**: FOSSA project configuration
  - Project naming: `SolaceProducts_pubsubplus-connector-spark`
  - Labels: MI, repository, connectors-coe
  - Path exclusions: `target/`, `src/test`, `samples/`, `src/docs`
  - Vendored dependency scanning enabled

## CI/CD Workflows

- **`.github/workflow-config.json`**: Centralized FOSSA and build configuration
  - FOSSA policy mode: REPORT (informational, non-blocking)
  - Vulnerability mode: REPORT (informational only)
  - Public repository configuration (uses GitHub Secrets)
  - Build settings: Java 17 (zulu), Maven, connectors-coe squad

- **`.github/workflows/ci-pr.yaml`**: PR workflow with FOSSA scanning
  - Runs FOSSA on all PRs (parallel with builds)
  - No merge queue support needed (disabled for this repo)
  - Enforces license compliance visibility before merge
  - Uses GitHub Secrets for FOSSA_API_KEY

- **`.github/workflows/release.yml`**: Release workflow with FOSSA scanning (updated)
  - Runs FOSSA before deployment to GitHub Packages and Maven Central
  - Sequential pattern: FOSSA must pass before artifacts are published
  - **Admin bypass option**: `skip_fossa` input for emergencies when FOSSA site is down
  - Uses release version tag for accurate tracking

- **`.github/workflows/fossa-scan.yaml`**: Manual FOSSA scan trigger
  - Allows ad-hoc scans on any branch
  - Useful for testing before opening PRs

## Verification

- ✅ Manual FOSSA scan completed successfully on `master` branch
- ✅ Baseline established in FOSSA cloud
- ✅ No license policy violations found
- 📊 Project: https://app.fossa.com/projects/custom%252b48578%252fSolaceProducts_pubsubplus-connector-spark

## Release Workflow Behavior

**Normal operation:**
1. FOSSA scans the release version
2. If FOSSA passes → Artifacts deploy to GitHub Packages and Maven Central
3. If FOSSA fails → Release is blocked

**Emergency bypass (admin only):**
- Set `skip_fossa: true` when triggering the release workflow
- Use ONLY if FOSSA site is down or unavailable
- Release proceeds without FOSSA scan

## Next Steps After Merge

1. **Add FOSSA_API_KEY to repository secrets** (REQUIRED):
   - Go to Settings → Secrets and variables → Actions
   - Add new repository secret: `FOSSA_API_KEY`
   - Get API key from: https://app.fossa.com/account/settings/tokens
   - This is required for FOSSA workflows to run

2. **Optional - Set up branch protection**:
   - Go to Settings → Branches
   - Edit protection rule for master branch
   - Enable "Require status checks to pass"
   - Add FOSSA check: `FOSSA Scan / license-scan`
   - Note: With REPORT mode, FOSSA won't block merges but provides visibility

3. **Monitor first scan**: FOSSA will run automatically on the next PR

4. **Review policy mode**: Currently set to REPORT mode (non-blocking)
   - Good for initial rollout and monitoring
   - Can change to BLOCK mode later in workflow-config.json for strict enforcement

## Testing Instructions

1. After adding `FOSSA_API_KEY` secret, open a test PR
2. Verify FOSSA scan runs and completes
3. Check FOSSA results in PR checks
4. Test manual workflow: Actions → Manual FOSSA Scan → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)