### PR TITLE
DATAGO-142151: Updated docs regarding SolaceSparkStreamingProperties changes

### DIFF
--- a/src/docs/asciidoc/User-Guide.adoc
+++ b/src/docs/asciidoc/User-Guide.adoc
@@ -96,7 +96,7 @@ The connector supports multiple checkpoint storage options depending on the depl
 To enable this, the following must be configured:
 
 * <<spark-runtime-platform, Spark Runtime Platform>> — Set to DATABRICKS to enable Unity Catalog Volume support
-* <<databricks-secret-scope, Secret Scope>> — A https://docs.databricks.com/aws/en/security/secrets/?language=Databricks%C2%A0CLI#create-a-secret-scope[Databricks secret scope] containing the workspace level service principal credentials (<<databricks-host, databricks_host>>, <<databricks-client-id, databricks_client_id>>, <<databricks-client-secret, databricks_client_secret>>)
+* <<databricks-secret-scope, Secret Scope>> — A https://docs.databricks.com/aws/en/security/secrets/?language=Databricks%C2%A0CLI#create-a-secret-scope[Databricks secret scope] containing the workspace level service principal credentials (<<databricks-host, databricksHost>>, <<databricks-client-id, databricksClientId>>, <<databricks-client-secret, databricksClientSecret>>)
 * <<databricks-client-secret-refresh-interval, Client Secret Refresh Interval>> — Controls how frequently the connector fetches updated client secret from the secret scope to handle client secret rotation without requiring a restart
 
 IMPORTANT: Both client secret rotation and the connector's client secret refresh must complete before the secret expires. The refresh interval must be configured to trigger after rotation completes and before the existing secret expires. See the configuration section for detailed guidance on configuring the refresh interval correctly.

--- a/src/docs/sections/general/configuration/solace-spark-source-config.adoc
+++ b/src/docs/sections/general/configuration/solace-spark-source-config.adoc
@@ -258,7 +258,7 @@ a| Runtime platform on which the Spark application is deployed. Required when a 
 | string
 | valid secret name
 | empty
-a| Secret name within the configured secret scope that holds the Databricks workspace host URL. Required when `spark_runtime_platform` is `DATABRICKS` and the checkpoint path contains `Volumes`.
+a| Secret name within the configured secret scope that holds the Databricks workspace host URL. Required when `sparkRuntimePlatform` is `DATABRICKS` and the checkpoint path contains `Volumes`.
 
 Refer to https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth-m2m#step-2-use-oauth-authorization[Databricks OAuth Workspace level Environment Variables] for valid host value
 
@@ -266,7 +266,7 @@ Refer to https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth
 | string
 | valid secret name
 | empty
-a| Secret name within the configured secret scope that holds the Databricks service principal client ID. Required when `spark_runtime_platform` is `DATABRICKS` and the checkpoint path contains `Volumes`.
+a| Secret name within the configured secret scope that holds the Databricks service principal client ID. Required when `sparkRuntimePlatform` is `DATABRICKS` and the checkpoint path contains `Volumes`.
 
 For relevant value refer to https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth-m2m#step-2-use-oauth-authorization[Databricks OAuth Workspace level Environment Variables] for valid client id value
 
@@ -276,7 +276,7 @@ NOTE: Ensure the service principal has access to the configured Unity Catalog Vo
 | string
 | valid secret name
 | empty
-a| Secret name within the configured secret scope that holds the Databricks service principal client secret. Required when `spark_runtime_platform` is `DATABRICKS` and the checkpoint path is `Unity Catalog Volume`.
+a| Secret name within the configured secret scope that holds the Databricks service principal client secret. Required when `sparkRuntimePlatform` is `DATABRICKS` and the checkpoint path is `Unity Catalog Volume`.
 
 For relevant values refer to https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth/oauth-m2m#step-2-use-oauth-authorization[Databricks OAuth Workspace level Environment Variables] for valid client secret value
 
@@ -302,4 +302,4 @@ Databricks Client Secret — Important Notes
 
 NOTE: Always manage this credential using Databricks secret scopes. Never expose it in plain text.
 
-IMPORTANT: Secret rotation is not managed by the connector. The platform administrator is responsible for rotating the secret and updating it in the secret scope. The connector fetches the updated secret automatically based on the interval configured in `databricks_client_secret_refresh_interval`. No restart is required.
+IMPORTANT: Secret rotation is not managed by the connector. The platform administrator is responsible for rotating the secret and updating it in the secret scope. The connector fetches the updated secret automatically based on the interval configured in `databricksClientSecretRefreshInterval`. No restart is required.


### PR DESCRIPTION
## Summary

Corrects stale property names left in the AsciiDoc documentation after [#56](https://github.com/SolaceProducts/pubsubplus-connector-spark/pull/56) (DATAGO-130445) renamed the Databricks / Unity Catalog properties from `snake_case` to `camelCase`.

That PR renamed the constants in `SolaceSparkStreamingProperties.java` and updated the property-table **row names**, but the old names survived in the surrounding prose and in a cross-reference list. Those names no longer exist in the code, so a user copying them would set a key the connector silently ignores.

## Changes

Docs only — five lines across two files, covering five properties:

| Old (stale in docs) | Correct |
|---|---|
| `spark_runtime_platform` | `sparkRuntimePlatform` |
| `databricks_host` | `databricksHost` |
| `databricks_client_id` | `databricksClientId` |
| `databricks_client_secret` | `databricksClientSecret` |
| `databricks_client_secret_refresh_interval` | `databricksClientSecretRefreshInterval` |

- **`src/docs/sections/general/configuration/solace-spark-source-config.adoc`** — three `sparkRuntimePlatform` references in the `databricksHost` / `databricksClientId` / `databricksClientSecret` descriptions, plus `databricksClientSecretRefreshInterval` in the secret-rotation note.
- **`src/docs/asciidoc/User-Guide.adoc`** — the three credential names in the Checkpoint Storage cross-reference list.

## Notes

- AsciiDoc anchor slugs are unchanged. They remain kebab-case (`sparkRuntimePlatform[[spark-runtime-platform]]`), so only display names and prose text changed; all cross-references still resolve.
- No functional change: no Java, build, or dependency changes, and no property was renamed or added in this PR.