### PR TITLE
DATAGO-147861: Change Maven coordinates to com.solace:solace-connector-spark-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For complete user guide, please check the connector page on [Solace Integration 
 
 ## Maven Central
 
-The connector is available in maven central as [pubsubplus-connector-spark](https://mvnrepository.com/artifact/com.solacecoe.connectors/pubsubplus-connector-spark)
+The connector is available in maven central as [solace-connector-spark-4](https://mvnrepository.com/artifact/com.solace/solace-connector-spark-4)
 
 # Build the connector
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 <!--        <version>${revision}${sha1}${changelist}</version>-->
 <!--    </parent>-->
 
-    <groupId>com.solacecoe.connectors</groupId>
-    <artifactId>pubsubplus-connector-spark</artifactId>
+    <groupId>com.solace</groupId>
+    <artifactId>solace-connector-spark-4</artifactId>
     <version>${revision}${sha1}${changelist}</version>
 
     <properties>
@@ -20,7 +20,7 @@
         Project Versioning Properties
         ===================================
         -->
-        <revision>4.0.1</revision>
+        <revision>1.0.0</revision>
         <sha1/> <!-- Doesn't actually need to be a sha1, this is just another version modifier variable -->
         <changelist>-SNAPSHOT</changelist>
         <next-revision>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}</next-revision>
@@ -755,8 +755,10 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <!-- Staged review: the deployment is uploaded and validated but not
+                                 published. Release it manually from the Central Portal. -->
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/docs/sections/general/quick-start/quick-start.adoc
+++ b/src/docs/sections/general/quick-start/quick-start.adoc
@@ -11,8 +11,8 @@ Solace Spark Connector is available in maven central with below coordinates.
 [source,xml,subs="+attributes"]
 ----
 <dependency>
-    <groupId>com.solacecoe.connectors</groupId>
-    <artifactId>pubsubplus-connector-spark</artifactId>
+    <groupId>com.solace</groupId>
+    <artifactId>solace-connector-spark-4</artifactId>
     <version>{version}</version>
 </dependency>
 ----


### PR DESCRIPTION
[DATAGO-147861](https://sol-jira.atlassian.net/browse/DATAGO-147861)

Moves the Spark 4.x line to its new Maven coordinates and switches Central releases to staged review.

Targets `spark_4.X`, not `master` — per the ticket comment, `master` keeps `com.solacecoe.connectors` at 3.x for the Spark 3.x / Scala 2.12 line and is untouched here.

## Changes

| | Before | After |
|---|---|---|
| `groupId` | `com.solacecoe.connectors` | `com.solace` |
| `artifactId` | `pubsubplus-connector-spark` | `solace-connector-spark-4` |
| `revision` | `4.0.1` | `1.0.0` |
| `autoPublish` | `true` | `false` |
| `waitUntil` | `published` | `validated` |

`revision` drops to `1.0.0` per the ticket comment's "keeping the versioning 1.X" — the Spark major version is now carried by the artifactId instead of the version.

The docs changes are the user-facing dependency snippet in `quick-start.adoc` and the mvnrepository link in `README.md`. Left as-is they would point users at coordinates that will not exist for the 4.x line.

## Note on `waitUntil`

Turning off `autoPublish` alone would hang the release job. `waitUntil=published` polls until something publishes the deployment, and with `autoPublish=false` nothing will, so the step would sit until the workflow timeout. `validated` waits for Central's validation to pass and then exits green, leaving the deployment in the portal for review. This one was not in the ticket text.

## Verified

- Resolved coordinates are `com.solace` / `solace-connector-spark-4` / `1.0.0-SNAPSHOT`
- The generated `.flattened-pom.xml` — the POM actually deployed — carries the new GAV, confirming the ticket's POM-only finding
- The `releaseCentral` effective POM resolves `autoPublish=false` / `waitUntil=validated`
- Java packages stay `com.solacecoe.connectors.spark`; that namespace is independent of the Maven GAV
- GitHub Packages unaffected — `distributionManagement` points at the repository URL, so the new artifactId just creates a new package

## Blocked on, outside this PR

A release will still fail at deploy until EngPlat completes the two portal/Vault items on the ticket: verifying the `com.solace` namespace on the Central Portal, and confirming the `MAVEN_USERNAME` / `MAVEN_PASSWORD` credentials from `secret/data/tools/githubactions` are authorized for it.

Also unaddressed: the `release_central` `workflow_dispatch` input is declared at `release.yml:8-15` but never referenced, so "Deploy Artifacts (Maven Central)" runs on every release regardless of the selection. Left alone to avoid changing release behavior beyond this ticket's scope, but worth a follow-up now that Central deploys stage rather than publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)