### PR TITLE
DATAGO-149324: Fixes for Findings 1, 2, 3 & 4

### DIFF
--- a/.flattened-pom.xml
+++ b/.flattened-pom.xml
@@ -40,20 +40,20 @@
     </site>
   </distributionManagement>
   <properties>
-    <shared-remote-resources.build.main.processed.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/shared-remote-resources/build/main/processed</shared-remote-resources.build.main.processed.directory>
-    <shared-remote-resources.process.asciidoctor-resources.skip>false</shared-remote-resources.process.asciidoctor-resources.skip>
-    <release-notes.url>https://solace.com/integration-hub/apache-spark</release-notes.url>
-    <changelist>-SNAPSHOT</changelist>
-    <maven.compiler.target>8</maven.compiler.target>
-    <shared-remote-resources.build.main.raw.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/shared-remote-resources/build/main/raw</shared-remote-resources.build.main.raw.directory>
     <docs.build.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/generated-docs</docs.build.directory>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <revision>3.1.7</revision>
-    <sha1></sha1>
-    <next-revision>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}</next-revision>
-    <generated-filtered-resource.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/generated-filtered-resources</generated-filtered-resource.directory>
     <maven.compiler.source>8</maven.compiler.source>
     <shared-remote-resources.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/shared-remote-resources</shared-remote-resources.directory>
+    <shared-remote-resources.process.asciidoctor-resources.skip>false</shared-remote-resources.process.asciidoctor-resources.skip>
+    <release-notes.url>https://solace.com/integration-hub/apache-spark</release-notes.url>
+    <shared-remote-resources.build.main.processed.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/shared-remote-resources/build/main/processed</shared-remote-resources.build.main.processed.directory>
+    <generated-filtered-resource.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/generated-filtered-resources</generated-filtered-resource.directory>
+    <revision>3.1.7</revision>
+    <next-revision>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.nextIncrementalVersion}</next-revision>
+    <sha1></sha1>
+    <maven.compiler.target>8</maven.compiler.target>
+    <shared-remote-resources.build.main.raw.directory>/Users/sravanthotakura/Work/tech-coe/connectors/solace-dev/latest/spark-connector-v2/target/shared-remote-resources/build/main/raw</shared-remote-resources.build.main.raw.directory>
+    <changelist>-SNAPSHOT</changelist>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/.flattened-pom.xml
+++ b/.flattened-pom.xml
@@ -68,6 +68,11 @@
         <version>2.15.0</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.18.9</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.25.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
                 <version>2.15.0</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.18.9</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>3.25.5</version>

--- a/src/docs/asciidoc/User-Guide.adoc
+++ b/src/docs/asciidoc/User-Guide.adoc
@@ -53,15 +53,16 @@ In case if you are using Shared compute cluster, make sure your cluster has http
 
 === Handling Idle Connections
 
-The connector provides the ability to terminate idle connections when there is no data available in queue for processing or if spark session is not gracefully terminated.
+The connector provides the ability to terminate idle connections when there is no data available in the queue for processing, when a solace producer has no data to publish, or if the Spark session is not gracefully terminated.
 
 To manage this, it is recommended to configure the following parameters:
 
 . <<connect-idle-timeout-in-millis, Idle Connection Timeout in Milliseconds>>: Specifies the maximum duration a connection can remain idle before being considered for closure.
 . <<connect-idle-timeout-check-in-millis, Idle Connection Timeout Check in Milliseconds>>: Defines the interval at which idle connections are checked.
-The Solace Spark Connector monitors the time since the last processed message. If this duration exceeds the configured idle timeout, the connector closes the idle connection.
 
-NOTE: Both configurations are disabled by default and must be explicitly set to enable this feature. Any pending messages to be acknowledged will be redelivered and the downstream should be idempotent to handle duplicates. The connection will be re-established in case of restart(job or notebook) or if new messages arrive in the queue(job or notebook should be up and running).
+The Solace Spark Connector monitors the time since the last processed or published message. If this duration exceeds the configured idle timeout, the connector closes the idle connection. This applies to both consumer connections (when no messages are available in the queue) and solace producer connections (when there are no messages to publish).
+
+NOTE: Both configurations are disabled by default and must be explicitly set to enable this feature. Any pending unacknowledged messages will be redelivered, so downstream processing should be idempotent to handle duplicates. The connection is re-established on restart (job or notebook), when new messages arrive in the queue for consumption, or when a solace producer has new messages to publish (provided the job or notebook is up and running).
 
 === Checkpointing & Acknowledgement
 

--- a/src/docs/sections/general/configuration/solace-spark-sink-config.adoc
+++ b/src/docs/sections/general/configuration/solace-spark-sink-config.adoc
@@ -57,6 +57,18 @@
 | 3000
 | How much time in (MS) to wait between each attempt to connect or reconnect to a host. If a connect or reconnect attempt to host is not successful, the API waits for the amount of time set for reconnectRetryWaitInMillis, and then makes another connect or reconnect attempt.
 
+| producerSessionCreateRetries
+| int
+| 0 or greater
+| 3
+| Number of retry attempts if creating the producer session fails due to a transient issue (for example, a DNS resolution failure). The producer session is created once per partition and reused across micro-batches; this property only applies when that session needs to be (re)created. 0 means no retries; the connector fails the write task immediately on the first failure.
+
+| producerSessionCreateRetryIntervalInMillis
+| int
+| positive integer
+| 1000
+| Initial wait time in milliseconds before retrying a failed producer session creation. Doubles after each subsequent retry (exponential backoff).
+
 | solace.apiProperties.<Property>
 | any
 | any

--- a/src/docs/sections/general/configuration/solace-spark-sink-config.adoc
+++ b/src/docs/sections/general/configuration/solace-spark-sink-config.adoc
@@ -69,6 +69,18 @@
 | 1000
 | Initial wait time in milliseconds before retrying a failed producer session creation. Doubles after each subsequent retry (exponential backoff).
 
+| connectIdleTimeoutInMillis[[connect-idle-timeout-in-millis]]
+| int
+| Timeout in Milliseconds
+| 0
+| Time in milliseconds before closing an idle connection to Solace. Useful in long-running clusters where Spark sessions do not terminate gracefully.
+
+| connectIdleTimeoutCheckInMillis[[connect-idle-timeout-check-in-millis]]
+| int
+| Timeout in Milliseconds
+| 0
+| Interval in milliseconds at which to check for idle connections. Connections idle beyond the configured timeout are closed automatically.
+
 | solace.apiProperties.<Property>
 | any
 | any

--- a/src/docs/sections/general/configuration/solace-spark-source-config.adoc
+++ b/src/docs/sections/general/configuration/solace-spark-source-config.adoc
@@ -166,6 +166,29 @@ a| Password for the JKS trust store file.
 | 10000
 | Maximum time to wait before submitting available messages to a Spark micro-batch.
 
+| queueFullCheckWaitTimeoutInMillis
+| int
+| positive integer
+| 1000
+| Maximum time to wait, per attempt, when checking whether the queue has messages available before starting a micro-batch.
+
+| queueFullCheckRetries
+| int
+| positive integer
+| 5
+| Number of polling attempts, each bounded by `queueFullCheckWaitTimeoutInMillis`, before concluding the queue is empty and skipping the micro-batch.
+
+| reuseBrowserConnections
+| boolean
+| true or false
+| true
+a| Controls whether the Browser connections used to check LVQ checkpoints and queue depth are held open and reused across micro-batches, or recreated on every check.
+
+* `true` — the two Browser flows are provisioned once and reused for the life of the query. Fewer broker-side flow provision/teardown round-trips, at the cost of 2 standing egress flows per query.
+* `false` — a new Browser is provisioned and torn down on every check. No standing flows between micro-batches, at the cost of additional broker-side provisioning overhead per micro-batch.
+
+Set to `false` if running many concurrent queries against a broker with a constrained egress flow limit (see your Solace service's client profile / service class limits).
+
 | batchSize
 | int
 | any
@@ -227,6 +250,18 @@ NOTE: Enable only when the downstream system has successfully processed data in 
 | valid solace topic
 | empty
 | Topic subscribed by the LVQ on the Solace broker. Each worker node publishes checkpoint information to this topic.
+
+| lvqPublishRetries
+| int
+| 0 or greater
+| 3
+| Number of retry attempts when publishing checkpoint data to the LVQ fails due to a transient connection issue (for example, a broker-side disconnect). 0 means no retries; the connector fails the query immediately on the first failure.
+
+| lvqPublishRetryIntervalInMillis
+| int
+| positive integer
+| 1000
+| Initial wait time in milliseconds before retrying a failed LVQ checkpoint publish. Doubles after each subsequent retry (exponential backoff).
 
 | ignoreCheckpointMessageIdComparisonError
 | boolean

--- a/src/docs/sections/general/configuration/solace-spark-source-config.adoc
+++ b/src/docs/sections/general/configuration/solace-spark-source-config.adoc
@@ -181,7 +181,7 @@ a| Password for the JKS trust store file.
 | reuseBrowserConnections
 | boolean
 | true or false
-| true
+| false
 a| Controls whether the Browser connections used to check LVQ checkpoints and queue depth are held open and reused across micro-batches, or recreated on every check.
 
 * `true` — the two Browser flows are provisioned once and reused for the life of the query. Fewer broker-side flow provision/teardown round-trips, at the cost of 2 standing egress flows per query.

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/SolaceMicroBatch.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/SolaceMicroBatch.java
@@ -57,7 +57,6 @@ public class SolaceMicroBatch implements MicroBatchStream {
 //    private CopyOnWriteArrayList<SolaceSparkPartitionCheckpoint> checkpoints;
     private Map<String, String> properties = new HashMap<>();
     private final SolaceBroker solaceBroker;
-    private String lastKnownMessageIds = "";
     private String queueName = "";
     private CopyOnWriteArrayList<SolaceSparkPartitionCheckpoint> currentCheckpoint = new CopyOnWriteArrayList<>();
     private final String checkpointLocation;
@@ -173,7 +172,6 @@ public class SolaceMicroBatch implements MicroBatchStream {
         checkException();
         latestOffsetId+=batchSize;
         if(currentCheckpoint != null && !currentCheckpoint.isEmpty()) {
-            currentCheckpoint.forEach(checkpoint -> lastKnownMessageIds = String.join(",", lastKnownMessageIds, checkpoint.getMessageIDs()));
             return new SolaceSourceOffset(latestOffsetId, currentCheckpoint);
         } else {
             currentCheckpoint = new CopyOnWriteArrayList<>();
@@ -274,7 +272,6 @@ public class SolaceMicroBatch implements MicroBatchStream {
         CopyOnWriteArrayList<SolaceSparkPartitionCheckpoint> existingCheckpoints = this.getCheckpoint();
         if(existingCheckpoints != null && !existingCheckpoints.isEmpty()) {
             currentCheckpoint = existingCheckpoints;
-            existingCheckpoints.forEach(checkpoint -> lastKnownMessageIds = String.join(",", lastKnownMessageIds, checkpoint.getMessageIDs()));
             log.info("SolaceSparkConnector - Checkpoint available from LVQ {}", new Gson().toJson(existingCheckpoints));
             return new SolaceSourceOffset(lastKnownOffsetId, existingCheckpoints);
         }
@@ -292,7 +289,6 @@ public class SolaceMicroBatch implements MicroBatchStream {
         }
         lastKnownOffsetId = solaceSourceOffset.getOffset();
         currentCheckpoint = solaceSourceOffset.getCheckpoints();
-        solaceSourceOffset.getCheckpoints().forEach(checkpoint -> lastKnownMessageIds = String.join(",", lastKnownMessageIds, checkpoint.getMessageIDs()));
 
         return solaceSourceOffset;
     }

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/properties/SolaceSparkStreamingProperties.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/properties/SolaceSparkStreamingProperties.java
@@ -74,4 +74,28 @@ public class SolaceSparkStreamingProperties {
 //    public static final String DATABRICKS_CLIENT_SECRET_LIFETIME = "DATABRICKS_CLIENT_SECRET_LIFETIME";
 //    public static final String DATABRICKS_ROTATE_CLIENT_SECRET = "DATABRICKS_ROTATE_CLIENT_SECRET";
 //    public static final String DATABRICKS_ROTATE_CLIENT_SECRET_DEFAULT = "false";
+    // Retries + backoff around the LVQ checkpoint publish in SolaceMicroBatch.commit(), so a
+    // transient broker disconnect ("Channel is closed by peer") does not fail the query fatally.
+    public static final String LVQ_PUBLISH_RETRIES = "lvqPublishRetries";
+    public static final String LVQ_PUBLISH_RETRIES_DEFAULT = "3";
+    public static final String LVQ_PUBLISH_RETRY_INTERVAL = "lvqPublishRetryIntervalInMillis";
+    public static final String LVQ_PUBLISH_RETRY_INTERVAL_DEFAULT = "1000";
+    // Retries + backoff when creating/re-creating the producer JCSMP session used by SolaceDataWriter,
+    // so a transient DNS/connect failure doesn't fail the write task immediately.
+    public static final String PRODUCER_SESSION_CREATE_RETRIES = "producerSessionCreateRetries";
+    public static final String PRODUCER_SESSION_CREATE_RETRIES_DEFAULT = "3";
+    public static final String PRODUCER_SESSION_CREATE_RETRY_INTERVAL = "producerSessionCreateRetryIntervalInMillis";
+    public static final String PRODUCER_SESSION_CREATE_RETRY_INTERVAL_DEFAULT = "1000";
+    // Bounded wait/retry used by SolaceBroker.isQueueFull() on each micro-batch's driver-side poll.
+    public static final String QUEUE_FULL_CHECK_WAIT_TIMEOUT = "queueFullCheckWaitTimeoutInMillis";
+    public static final String QUEUE_FULL_CHECK_WAIT_TIMEOUT_DEFAULT = "1000";
+    public static final String QUEUE_FULL_CHECK_RETRIES = "queueFullCheckRetries";
+    public static final String QUEUE_FULL_CHECK_RETRIES_DEFAULT = "5";
+    // Whether the LVQ and queue-full-check Browser flows are held open and reused across micro-batches
+    // (fewer broker-side flow provision/teardown round-trips, at the cost of 2 standing egress flows for
+    // the life of the query) or recreated on every poll (zero standing flows, more broker-side churn).
+    // Operators on a flow-constrained broker tier or running many concurrent queries against the same
+    // broker may prefer to disable reuse.
+    public static final String REUSE_BROWSER_CONNECTIONS = "reuseBrowserConnections";
+    public static final String REUSE_BROWSER_CONNECTIONS_DEFAULT = "false";
 }

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
@@ -45,6 +45,13 @@ public class SolaceBroker implements Serializable {
     private XMLMessageProducer producer;
     private long lastMessageTimestamp = 0;
     private boolean isShuttingDown = false;
+    private final int lvqPublishRetries;
+    private final long lvqPublishRetryIntervalMillis;
+    private final int queueFullCheckWaitTimeout;
+    private final int queueFullCheckRetries;
+    private final boolean reuseBrowserConnections;
+    private transient Browser lvqBrowser;
+    private transient Browser queueBrowser;
 
     private Queue lvq;
 
@@ -55,6 +62,11 @@ public class SolaceBroker implements Serializable {
         this.lvqName = properties.getOrDefault(SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_NAME, SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_DEFAULT_NAME);
         this.lvqTopic = properties.getOrDefault(SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_TOPIC, SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_DEFAULT_TOPIC);
         this.queue = properties.getOrDefault(SolaceSparkStreamingProperties.QUEUE, "");
+        this.lvqPublishRetries = Integer.parseInt(properties.getOrDefault(SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRIES, SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRIES_DEFAULT));
+        this.lvqPublishRetryIntervalMillis = Long.parseLong(properties.getOrDefault(SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRY_INTERVAL, SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRY_INTERVAL_DEFAULT));
+        this.queueFullCheckWaitTimeout = Integer.parseInt(properties.getOrDefault(SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_WAIT_TIMEOUT, SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_WAIT_TIMEOUT_DEFAULT));
+        this.queueFullCheckRetries = Integer.parseInt(properties.getOrDefault(SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_RETRIES, SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_RETRIES_DEFAULT));
+        this.reuseBrowserConnections = Boolean.parseBoolean(properties.getOrDefault(SolaceSparkStreamingProperties.REUSE_BROWSER_CONNECTIONS, SolaceSparkStreamingProperties.REUSE_BROWSER_CONNECTIONS_DEFAULT));
         try {
             JCSMPProperties jcsmpProperties = new JCSMPProperties();
             // get api properties
@@ -242,15 +254,14 @@ public class SolaceBroker implements Serializable {
     }
 
     public CopyOnWriteArrayList<SolaceSparkPartitionCheckpoint> browseLVQ() {
-        BrowserProperties br_prop = new BrowserProperties();
-        br_prop.setEndpoint(lvq);
-        br_prop.setTransportWindowSize(1);
-        br_prop.setWaitTimeout(1000);
+        Browser myBrowser = null;
         try {
-            Browser myBrowser = session.createBrowser(br_prop);
-            BytesXMLMessage rx_msg = null;
+            myBrowser = reuseBrowserConnections ? getOrCreateLvqBrowser() : newLvqBrowser();
             log.info("SolaceSparkConnector - Browsing checkpoint from LVQ {}", this.lvqName);
-            rx_msg = myBrowser.getNext();
+            // Bounded getNext(timeout) rather than the no-arg getNext() — makes the wait explicit and
+            // independent of whatever internal state the Browser/BrowserProperties are in, instead of
+            // relying on getNext() to correctly thread through BrowserProperties.waitTimeout every time.
+            BytesXMLMessage rx_msg = myBrowser.getNext(1000);
             if (rx_msg != null) {
                 log.info("SolaceSparkConnector - Browsed checkpoint from LVQ {}", this.lvqName);
                 byte[] msgData = new byte[0];
@@ -265,12 +276,50 @@ public class SolaceBroker implements Serializable {
             } else {
                 log.info("SolaceSparkConnector - No checkpoint available in LVQ {}", this.lvqName);
             }
-            myBrowser.close();
             return lastKnownCheckpoint;
         } catch (JCSMPException e) {
             log.error("SolaceSparkConnector - Exception browsing LVQ {}", this.lvqName, e);
+            closeLvqBrowser();
             close();
             throw new RuntimeException(e);
+        } finally {
+            // In non-reuse mode myBrowser is never cached, so it must be torn down after every poll -
+            // otherwise the flow leaks on the broker instead of being provisioned fresh next time.
+            if (!reuseBrowserConnections && myBrowser != null) {
+                try {
+                    myBrowser.close();
+                } catch (Exception e) {
+                    log.warn("SolaceSparkConnector - Exception closing LVQ browser {}", this.lvqName, e);
+                }
+            }
+        }
+    }
+
+    private Browser newLvqBrowser() throws JCSMPException {
+        BrowserProperties br_prop = new BrowserProperties();
+        br_prop.setEndpoint(lvq);
+        br_prop.setTransportWindowSize(1);
+        br_prop.setWaitTimeout(1000);
+        return session.createBrowser(br_prop);
+    }
+
+    private Browser getOrCreateLvqBrowser() throws JCSMPException {
+        // Reused across micro-batches instead of provisioning/tearing down a broker-side flow every
+        // call - only ever invoked sequentially from the driver's offset thread, so no locking needed.
+        if (lvqBrowser == null) {
+            lvqBrowser = newLvqBrowser();
+        }
+        return lvqBrowser;
+    }
+
+    private void closeLvqBrowser() {
+        if (lvqBrowser != null) {
+            try {
+                lvqBrowser.close();
+            } catch (Exception e) {
+                log.warn("SolaceSparkConnector - Exception closing LVQ browser {}", this.lvqName, e);
+            }
+            lvqBrowser = null;
         }
     }
 
@@ -310,38 +359,72 @@ public class SolaceBroker implements Serializable {
 //    }
 
     public boolean isQueueFull() {
+        Browser browser = null;
         try {
-            BrowserProperties br_prop = new BrowserProperties();
-            br_prop.setEndpoint(JCSMPFactory.onlyInstance().createQueue(this.queue));
-            br_prop.setTransportWindowSize(1);
-            br_prop.setWaitTimeout(1000);
-            Browser queueBrowser = session.createBrowser(br_prop);
-            int retryCount = 0;
-            BytesXMLMessage rx_msg = null;
-            do {
-                rx_msg = queueBrowser.getNext();
+            browser = reuseBrowserConnections ? getOrCreateQueueBrowser() : newQueueBrowser();
+            for (int attempt = 1; attempt <= queueFullCheckRetries; attempt++) {
+                // Bounded getNext(timeout) rather than the no-arg getNext() — makes the wait explicit
+                // instead of relying on getNext() to correctly thread through BrowserProperties.waitTimeout.
+                // Independently reproduced root cause of the driver's offset thread hanging for 80+ minutes.
+                BytesXMLMessage rx_msg = browser.getNext(queueFullCheckWaitTimeout);
                 if (rx_msg != null) {
-                    queueBrowser.close();
                     return true;
-                } else {
-                    if(retryCount == 5) {
-                        queueBrowser.close();
-                        return false;
-                    }
                 }
-
-                retryCount++;
-            } while (true);
+            }
+            return false;
         } catch (JCSMPException e) {
             log.error("SolaceSparkConnector - Exception creating monitoring consumer on queue {}", this.queue, e);
+            closeQueueBrowser();
             close();
             handleException("SolaceSparkConnector - Exception creating monitoring consumer on queue " + this.queue, e);
             return false;
+        } finally {
+            // In non-reuse mode browser is never cached, so it must be torn down after every poll -
+            // otherwise the flow leaks on the broker instead of being provisioned fresh next time.
+            if (!reuseBrowserConnections && browser != null) {
+                try {
+                    browser.close();
+                } catch (Exception e) {
+                    log.warn("SolaceSparkConnector - Exception closing queue browser {}", this.queue, e);
+                }
+            }
+        }
+    }
+
+    private Browser newQueueBrowser() throws JCSMPException {
+        BrowserProperties br_prop = new BrowserProperties();
+        br_prop.setEndpoint(JCSMPFactory.onlyInstance().createQueue(this.queue));
+        br_prop.setTransportWindowSize(1);
+        br_prop.setWaitTimeout(queueFullCheckWaitTimeout);
+        return session.createBrowser(br_prop);
+    }
+
+    private Browser getOrCreateQueueBrowser() throws JCSMPException {
+        // Reused across micro-batches instead of provisioning/tearing down a broker-side flow every
+        // call - only ever invoked sequentially from the driver's offset thread, so no locking needed.
+        if (queueBrowser == null) {
+            queueBrowser = newQueueBrowser();
+        }
+        return queueBrowser;
+    }
+
+    private void closeQueueBrowser() {
+        if (queueBrowser != null) {
+            try {
+                queueBrowser.close();
+            } catch (Exception e) {
+                log.warn("SolaceSparkConnector - Exception closing queue browser {}", this.queue, e);
+            }
+            queueBrowser = null;
         }
     }
 
     public void initProducer(JCSMPStreamingPublishCorrelatingEventHandler jcsmpStreamingPublishCorrelatingEventHandler) {
         try {
+            // Close any previously bound producer first — this session/broker may be reused across
+            // micro-batches (see SolaceDataWriter's per-partition broker cache), and each reuse rebinds
+            // a fresh producer + ack-correlation handler scoped to the new writer instance.
+            closeProducer();
             this.producer = this.session.getMessageProducer(jcsmpStreamingPublishCorrelatingEventHandler);
         } catch (JCSMPException e) {
             log.error("SolaceSparkConnector - Error creating publisher to Solace", e);
@@ -374,12 +457,33 @@ public class SolaceBroker implements Serializable {
         xmlMessage.writeBytes(msg.toString().getBytes(StandardCharsets.UTF_8));
         xmlMessage.setDeliveryMode(DeliveryMode.PERSISTENT);
         Destination destination = JCSMPFactory.onlyInstance().createTopic(topic);
-        try {
-            this.producer.send(xmlMessage, destination);
-            log.info("SolaceSparkConnector - Published checkpoint to LVQ topic {}", topic);
-        } catch (JCSMPException e) {
-            log.error("SolaceSparkConnector - Exception publishing lvq message to Solace", e);
-            handleException("SolaceSparkConnector - Exception publishing lvq message to Solace ", e);
+        // A transport-level disconnect (e.g. "Channel is closed by peer") is a routine, recoverable
+        // event over a multi-day session - the JCSMP session already auto-reconnects in the background
+        // per the configured reconnectRetries/reconnectRetryWaitInMillis channel properties. Retry with
+        // backoff here gives that reconnect time to complete instead of failing the query fatally.
+        long backoff = lvqPublishRetryIntervalMillis;
+        for (int attempt = 0; attempt <= lvqPublishRetries; attempt++) {
+            try {
+                this.producer.send(xmlMessage, destination);
+                log.info("SolaceSparkConnector - Published checkpoint to LVQ topic {}", topic);
+                return;
+            } catch (JCSMPException e) {
+                if (attempt == lvqPublishRetries) {
+                    log.error("SolaceSparkConnector - Exception publishing lvq message to Solace after {} attempt(s)", attempt + 1, e);
+                    handleException("SolaceSparkConnector - Exception publishing lvq message to Solace ", e);
+                    return;
+                }
+                log.warn("SolaceSparkConnector - Exception publishing checkpoint to LVQ (attempt {}/{}). Retrying in {} ms to allow session to reconnect",
+                        attempt + 1, lvqPublishRetries + 1, backoff, e);
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    handleException("SolaceSparkConnector - Interrupted while retrying LVQ publish", ie);
+                    return;
+                }
+                backoff *= 2;
+            }
         }
     }
 
@@ -459,6 +563,8 @@ public class SolaceBroker implements Serializable {
             shutdownExecutor();
             closeProducer();
             closeReceivers();
+            closeLvqBrowser();
+            closeQueueBrowser();
 
             log.info("Closing Solace Session");
             if(session != null && !session.isClosed()) {

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/solace/SolaceBroker.java
@@ -718,16 +718,16 @@ public class SolaceBroker implements Serializable {
                 }
 
                 if (lastMessageTimestamp > 0 && (System.currentTimeMillis() - lastMessageTimestamp) > timeout) {
-                    log.info("SolaceSparkConnector - Inactivity timeout for consumer session {}. Last message processed at {}. Closing Session.", this.uniqueName, lastMessageTimestamp);
+                    log.info("SolaceSparkConnector - Inactivity timeout for session {}. Last message processed at {}. Closing Session.", this.uniqueName, lastMessageTimestamp);
                     close();
                 } else if(lastMessageTimestamp == 0){
-                    log.info("SolaceSparkConnector - No messages are processed yet by consumer session {}, skipping idle timeout check.", this.uniqueName);
+                    log.info("SolaceSparkConnector - No messages are processed yet by session {}, skipping idle timeout check.", this.uniqueName);
                 } else {
-                    log.info("SolaceSparkConnector - Last message is processed by consumer session {} at {} and current timestamp is {}", this.uniqueName, this.lastMessageTimestamp, System.currentTimeMillis());
+                    log.info("SolaceSparkConnector - Last message is processed by session {} at {} and current timestamp is {}", this.uniqueName, this.lastMessageTimestamp, System.currentTimeMillis());
                 }
             }, interval, interval, TimeUnit.MILLISECONDS); // initial delay, then interval
         } else {
-            log.info("SolaceSparkConnector - No connection idle timeout is configured. Micro Integration will not check for idle connections.");
+            log.info("SolaceSparkConnector - No connection idle timeout is configured. Idle connections will not be monitored.");
         }
     }
 

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkSchemaProperties;
 import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkStreamingProperties;
 import com.solacecoe.connectors.spark.streaming.solace.SolaceBroker;
+import com.solacecoe.connectors.spark.streaming.solace.SolaceConnectionManager;
 import com.solacecoe.connectors.spark.streaming.solace.exceptions.SolacePublishAbortException;
 import com.solacecoe.connectors.spark.streaming.solace.exceptions.SolacePublishAckInterruptedException;
 import com.solacecoe.connectors.spark.streaming.solace.exceptions.SolacePublishAckTimeoutException;
@@ -32,10 +33,19 @@ import java.util.concurrent.*;
 
 public class SolaceDataWriter implements DataWriter<InternalRow> {
     private static final Logger log = LoggerFactory.getLogger(SolaceDataWriter.class);
+    // Prefix keeps producer connections in their own namespace within SolaceConnectionManager's shared
+    // map, so a writer's partitionId can never collide with a consumer's hash-derived partition key.
+    private static final String CONNECTION_ID_PREFIX = "producer-";
     private String topic;
     private String messageId;
     private final StructType schema;
     private final Map<String, String> properties;
+    // JCSMP producer sessions are expensive to create (DNS resolution, TLS handshake) and Spark calls
+    // DataWriterFactory.createWriter() once per partition per micro-batch. Caching per partition via
+    // SolaceConnectionManager - the same mechanism already used for consumer connections - is safe
+    // because Spark never runs two writers for the same partition concurrently: successive epochs for
+    // a given partition execute sequentially, so at most one writer per connection id is ever live.
+    private final String connectionId;
     private SolaceBroker solaceBroker;
     private final transient UnsafeProjection projection;
     private final ConcurrentHashMap<String, SolaceDataWriterCommitMessage> commitMessages;
@@ -46,27 +56,64 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
 //    private final boolean hasDefaultMessageId;
     private int publishedMessages = 0;
     private CompletableFuture<Void> allAcksReceived = new CompletableFuture<>();
-    public SolaceDataWriter(StructType schema, Map<String, String> properties) {
+    public SolaceDataWriter(StructType schema, Map<String, String> properties, int partitionId) {
         this.schema = schema;
         this.properties = properties;
+        this.connectionId = CONNECTION_ID_PREFIX + partitionId;
         this.includeHeaders = Boolean.parseBoolean(properties.getOrDefault(SolaceSparkStreamingProperties.INCLUDE_HEADERS, SolaceSparkStreamingProperties.INCLUDE_HEADERS_DEFAULT));
         this.topic = properties.getOrDefault(SolaceSparkStreamingProperties.TOPIC, null);
 //        this.messageId = properties.getOrDefault(SolaceSparkStreamingProperties.MESSAGE_ID, null);
         hasDefaultTopic = this.topic != null;
 //        hasDefaultMessageId = this.messageId != null;
         try {
-            this.solaceBroker = new SolaceBroker(properties, "producer");
+            this.solaceBroker = acquireBroker(connectionId, properties);
             this.solaceBroker.initProducer(getJCSMPStreamingPublishCorrelatingEventHandler());
         } catch (Exception e) {
+            SolaceConnectionManager.removeConnection(connectionId);
             if(this.solaceBroker != null) {
                 this.solaceBroker.close();
             }
-            throw new SolacePublishException(e.getCause());
+            throw new SolacePublishException(e.getCause() != null ? e.getCause() : e);
         }
 
         this.projection = createProjection();
         this.commitMessages = new ConcurrentHashMap<>();
         this.abortedMessages = new ConcurrentHashMap<>();
+    }
+
+    private static SolaceBroker acquireBroker(String connectionId, Map<String, String> properties) {
+        SolaceBroker cached = SolaceConnectionManager.getConnection(connectionId);
+        if (cached != null && cached.isConnected()) {
+            log.info("SolaceSparkConnector - Reusing existing producer session for connection {}", connectionId);
+            return cached;
+        }
+        if (cached != null) {
+            log.info("SolaceSparkConnector - Cached producer session for connection {} is no longer connected (idle timeout or prior failure). Establishing a new one.", connectionId);
+            SolaceConnectionManager.removeConnection(connectionId);
+        }
+
+        int maxRetries = Integer.parseInt(properties.getOrDefault(SolaceSparkStreamingProperties.PRODUCER_SESSION_CREATE_RETRIES, SolaceSparkStreamingProperties.PRODUCER_SESSION_CREATE_RETRIES_DEFAULT));
+        long backoff = Long.parseLong(properties.getOrDefault(SolaceSparkStreamingProperties.PRODUCER_SESSION_CREATE_RETRY_INTERVAL, SolaceSparkStreamingProperties.PRODUCER_SESSION_CREATE_RETRY_INTERVAL_DEFAULT));
+        for (int attempt = 0; ; attempt++) {
+            try {
+                SolaceBroker broker = new SolaceBroker(properties, "producer");
+                SolaceConnectionManager.addConnection(connectionId, broker);
+                return broker;
+            } catch (Exception e) {
+                if (attempt == maxRetries) {
+                    throw e;
+                }
+                log.warn("SolaceSparkConnector - Exception creating producer session for connection {} (attempt {}/{}). Retrying in {} ms",
+                        connectionId, attempt + 1, maxRetries + 1, backoff, e);
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new SolacePublishException(ie);
+                }
+                backoff *= 2;
+            }
+        }
     }
 
     private void publishMessages(UnsafeRow projectedRow) {
@@ -101,8 +148,13 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
             this.solaceBroker.publishMessage(this.messageId, this.topic,
                     partitionKey, payload, timestamp, headersMap);
             publishedMessages++;
+            // Marks the session as active so the existing connectIdleTimeoutInMillis/
+            // connectIdleTimeoutCheckInMillis watchdog (already used to bound idle consumer
+            // connections) also bounds idle cached producer connections, instead of leaving one
+            // standing connection per partition open indefinitely for the life of the query.
+            this.solaceBroker.setLastMessageTimestamp(System.currentTimeMillis());
         } catch (Exception e) {
-            this.solaceBroker.close();
+            SolaceConnectionManager.close(connectionId);
             throw new SolacePublishException(e.getCause());
         }
     }
@@ -186,7 +238,10 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
         log.info("SolaceSparkConnector - SolaceDataWriter Closed");
         commitMessages.clear();
         abortedMessages.clear();
-        this.solaceBroker.close();
+        // Deliberately not closing solaceBroker here — the underlying producer session is cached in
+        // SolaceConnectionManager and reused across micro-batches for this partition (see acquireBroker).
+        // It is torn down by SolaceConnectionManager's shutdown hooks on executor exit, by the idle
+        // timeout watchdog (see setLastMessageTimestamp above), or evicted on publish failure.
     }
 
     private UnsafeProjection createProjection() {

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriter.java
@@ -184,6 +184,15 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
     @Override
     public WriterCommitMessage commit() {
         checkForException();
+        if (publishedMessages == 0) {
+            // Nothing was published in this micro-batch for this partition (e.g. an idle/empty
+            // partition - entirely normal in streaming). allAcksReceived is only ever completed
+            // from responseReceivedEx(), which fires per actual publish ack; with zero messages
+            // published it would never fire, so waiting on it below would always spuriously time
+            // out after the full ackTimeout for acks that were never going to arrive.
+            log.info("SolaceSparkConnector - No messages published in this batch. Skipping acknowledgement wait.");
+            return new SolaceDataWriterCommitMessage(SolacePublishStatus.SUCCESS, "");
+        }
         long ackTimeout = Long.parseLong(this.properties.getOrDefault(SolaceSparkStreamingProperties.PUBLISH_ACK_TIMEOUT, SolaceSparkStreamingProperties.PUBLISH_ACK_TIMEOUT_DEFAULT));
         boolean failOnTimeout = Boolean.parseBoolean(this.properties.getOrDefault(
                 SolaceSparkStreamingProperties.PUBLISH_ACK_TIMEOUT_FAIL_ON_ERROR,
@@ -202,6 +211,7 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
 
         } catch (TimeoutException e) {
             if (failOnTimeout) {
+                close();
                 // Fail the batch — throws exception and stops processing
                 throw new SolacePublishAckTimeoutException(
                         String.format("SolaceSparkConnector - Timed out after %dms waiting for " +
@@ -214,9 +224,11 @@ public class SolaceDataWriter implements DataWriter<InternalRow> {
                         ackTimeout, publishedMessages, this.commitMessages.size());
             }
         } catch (ExecutionException e) {
+            close();
             throw new SolacePublishAckInterruptedException(
                     "SolaceSparkConnector - Error while waiting for acknowledgements", e);
         } catch (InterruptedException e) {
+            close();
             Thread.currentThread().interrupt();
             throw new SolacePublishAckInterruptedException(
                     "SolaceSparkConnector - Interrupted while waiting for acknowledgements", e);

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriterFactory.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceDataWriterFactory.java
@@ -18,6 +18,6 @@ public class SolaceDataWriterFactory implements DataWriterFactory, Serializable 
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
-        return new SolaceDataWriter(schema, properties);
+        return new SolaceDataWriter(schema, properties, partitionId);
     }
 }

--- a/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceStreamingDataWriterFactory.java
+++ b/src/main/java/com/solacecoe/connectors/spark/streaming/write/SolaceStreamingDataWriterFactory.java
@@ -19,6 +19,6 @@ public class SolaceStreamingDataWriterFactory implements StreamingDataWriterFact
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
-        return new SolaceDataWriter(schema, properties);
+        return new SolaceDataWriter(schema, properties, partitionId);
     }
 }

--- a/src/test/java/com/solacecoe/connectors/spark/BrowserLivenessValidationIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/BrowserLivenessValidationIT.java
@@ -1,0 +1,141 @@
+package com.solacecoe.connectors.spark;
+
+import com.solacecoe.connectors.spark.containers.SolaceTestContainer;
+import com.solacesystems.jcsmp.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Standalone empirical validation: does a single, long-lived JCSMP Browser instance continue to
+ * see NEW messages published to a queue after it has already been exhausted (getNext() returned
+ * null), or does it behave as a one-time snapshot that never sees anything published afterward?
+ *
+ * This directly validates the Browser-reuse fix applied to SolaceBroker.browseLVQ()/isQueueFull()
+ * for DATAGO-149324 Finding 4 — reusing one Browser across micro-batches instead of recreating it
+ * every call is only safe if the SAME Browser instance keeps delivering newly-arrived messages.
+ */
+@Testcontainers
+public class BrowserLivenessValidationIT {
+    private static SolaceTestContainer solaceTestContainer;
+    private static JCSMPSession session;
+    private static final String QUEUE_NAME = "browser-liveness-test-queue";
+
+    @BeforeAll
+    static void setup() throws Exception {
+        solaceTestContainer = new SolaceTestContainer("solace/solace-pubsub-standard:latest", Collections.emptyMap());
+        solaceTestContainer.start();
+
+        JCSMPProperties properties = new JCSMPProperties();
+        properties.setProperty(JCSMPProperties.HOST, solaceTestContainer.getOrigin(org.testcontainers.solace.Service.SMF));
+        properties.setProperty(JCSMPProperties.VPN_NAME, solaceTestContainer.getVpn());
+        properties.setProperty(JCSMPProperties.USERNAME, solaceTestContainer.getUsername());
+        properties.setProperty(JCSMPProperties.PASSWORD, solaceTestContainer.getPassword());
+        session = JCSMPFactory.onlyInstance().createSession(properties);
+        session.connect();
+
+        Queue queue = JCSMPFactory.onlyInstance().createQueue(QUEUE_NAME);
+        EndpointProperties endpointProperties = new EndpointProperties();
+        endpointProperties.setAccessType(EndpointProperties.ACCESSTYPE_NONEXCLUSIVE);
+        session.provision(queue, endpointProperties, JCSMPSession.FLAG_IGNORE_ALREADY_EXISTS | JCSMPSession.WAIT_FOR_CONFIRM);
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (session != null && !session.isClosed()) {
+            session.closeSession();
+        }
+        if (solaceTestContainer != null) {
+            solaceTestContainer.stop();
+        }
+    }
+
+    private void publish(String body) throws Exception {
+        CountDownLatch acked = new CountDownLatch(1);
+        AtomicReference<JCSMPException> failure = new AtomicReference<>();
+        XMLMessageProducer producer = session.getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+            @Override
+            public void responseReceivedEx(Object key) {
+                acked.countDown();
+            }
+
+            @Override
+            public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                failure.set(cause);
+                acked.countDown();
+            }
+        });
+        BytesXMLMessage msg = JCSMPFactory.onlyInstance().createMessage(BytesXMLMessage.class);
+        msg.writeBytes(body.getBytes(StandardCharsets.UTF_8));
+        msg.setDeliveryMode(DeliveryMode.PERSISTENT);
+        Queue queue = JCSMPFactory.onlyInstance().createQueue(QUEUE_NAME);
+        producer.send(msg, queue);
+        if (!acked.await(10, TimeUnit.SECONDS)) {
+            fail("Publish of '" + body + "' was not acknowledged within 10 seconds");
+        }
+        if (failure.get() != null) {
+            throw failure.get();
+        }
+        producer.close();
+    }
+
+    private String bodyOf(BytesXMLMessage msg) {
+        byte[] data = msg.getContentLength() != 0 ? msg.getBytes() : msg.getAttachmentByteBuffer().array();
+        return new String(data, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void reusedBrowserInstanceSeesMessagesPublishedAfterInitialExhaustion() throws Exception {
+        Queue queue = JCSMPFactory.onlyInstance().createQueue(QUEUE_NAME);
+        BrowserProperties browserProperties = new BrowserProperties();
+        browserProperties.setEndpoint(queue);
+        browserProperties.setTransportWindowSize(1);
+        browserProperties.setWaitTimeout(2000);
+
+        // Create the Browser ONCE — this is the exact reuse pattern applied in SolaceBroker.
+        Browser browser = session.createBrowser(browserProperties);
+
+        // 1. Publish msg1 BEFORE the browser has ever seen anything, browse it.
+        publish("msg1");
+        BytesXMLMessage first = browser.getNext(3000);
+        assertEquals("msg1", first != null ? bodyOf(first) : null,
+                "Expected the browser to see the message published before it started browsing");
+
+        // 2. Exhaust the browser — getNext() should now time out and return null,
+        //    exactly like isQueueFull()'s "queue appears empty" case.
+        BytesXMLMessage exhausted = browser.getNext(2000);
+        assertNull(exhausted, "Expected browser to report no messages once caught up");
+
+        // 3. Publish msg2 AFTER the browser reported empty — WITHOUT recreating the browser.
+        publish("msg2");
+
+        // 4. Call getNext() again on the SAME, already-"exhausted" Browser instance.
+        //    If Browser is a one-time snapshot, this will return null (or hang) forever — a real
+        //    feature failure for the reuse fix. If it's a live, ongoing cursor, this returns msg2.
+        BytesXMLMessage second = browser.getNext(5000);
+        assertEquals("msg2", second != null ? bodyOf(second) : null,
+                "REGRESSION: the reused Browser instance did NOT see a message published after " +
+                        "it was previously exhausted. This would mean the Browser-reuse fix in " +
+                        "SolaceBroker (Finding 4) is unsafe and must be reverted.");
+
+        // 5. Do it again for good measure — rule out a one-off fluke.
+        assertNull(browser.getNext(1000));
+        publish("msg3");
+        BytesXMLMessage third = browser.getNext(5000);
+        assertEquals("msg3", third != null ? bodyOf(third) : null,
+                "REGRESSION on second round-trip: reused Browser did not see msg3 either.");
+
+        browser.close();
+    }
+}

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceBrokerLvqPublishRetryIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceBrokerLvqPublishRetryIT.java
@@ -1,0 +1,127 @@
+package com.solacecoe.connectors.spark;
+
+import com.solacecoe.connectors.spark.base.SempV2Api;
+import com.solacecoe.connectors.spark.containers.SolaceTestContainer;
+import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkStreamingProperties;
+import com.solacecoe.connectors.spark.streaming.solace.SolaceBroker;
+import com.solacecoe.connectors.spark.streaming.solace.exceptions.SolaceSessionException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.solace.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DATAGO-149324 Finding 2: SolaceBroker.publishMessage(topic, msg) - the LVQ checkpoint publish used
+ * by SolaceMicroBatch.commit() - had no retry. A single transient transport exception (e.g. "Channel
+ * is closed by peer", a routine, recoverable event over a multi-day session) went straight to
+ * handleException() and killed the streaming query fatally.
+ *
+ * These tests run against a real Solace broker (Testcontainers) and use the SEMP action API to
+ * forcibly disconnect the client mid-test, reproducing the actual "Channel is closed by peer" failure
+ * class rather than a mocked exception.
+ */
+@Testcontainers
+class SolaceBrokerLvqPublishRetryIT {
+    private static SolaceTestContainer solaceTestContainer;
+    private static SempV2Api sempV2Api;
+    private static Map<String, String> baseProperties;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        solaceTestContainer = new SolaceTestContainer("solace/solace-pubsub-standard:latest", Collections.emptyMap());
+        solaceTestContainer.start();
+        sempV2Api = new SempV2Api(String.format("http://%s:%d", solaceTestContainer.getHost(), solaceTestContainer.getMappedPort(8080)), "admin", "admin");
+
+        baseProperties = new HashMap<>();
+        baseProperties.put(SolaceSparkStreamingProperties.HOST, solaceTestContainer.getOrigin(Service.SMF));
+        baseProperties.put(SolaceSparkStreamingProperties.VPN, solaceTestContainer.getVpn());
+        baseProperties.put(SolaceSparkStreamingProperties.USERNAME, solaceTestContainer.getUsername());
+        baseProperties.put(SolaceSparkStreamingProperties.PASSWORD, solaceTestContainer.getPassword());
+        // SolaceBroker's constructor reads this but browseLVQ()/isQueueFull() are never exercised here.
+        baseProperties.put(SolaceSparkStreamingProperties.QUEUE, "lvq-retry-test-queue-not-used");
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (solaceTestContainer != null) {
+            solaceTestContainer.stop();
+        }
+    }
+
+    private Map<String, String> propertiesWith(String... kv) {
+        Map<String, String> props = new HashMap<>(baseProperties);
+        for (int i = 0; i < kv.length; i += 2) {
+            props.put(kv[i], kv[i + 1]);
+        }
+        return props;
+    }
+
+    @Test
+    void publishSurvivesTransientDisconnectWithinRetryBudget() throws Exception {
+        Map<String, String> properties = propertiesWith(
+                SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRIES, "6",
+                SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRY_INTERVAL, "500",
+                // JCSMP's own session-level auto-reconnect - this is what actually heals the transport;
+                // our retry loop's job is only to give it time to do so instead of failing immediately.
+                SolaceSparkStreamingProperties.SOLACE_RECONNECT_RETRIES, "10",
+                SolaceSparkStreamingProperties.SOLACE_RECONNECT_RETRIES_WAIT_TIME, "300"
+        );
+        SolaceBroker broker = new SolaceBroker(properties, "producer");
+        try {
+            broker.createLVQIfNotExist();
+            broker.initProducer();
+
+            // Forcibly sever this client's transport at the broker - the same failure class as the
+            // customer's "Channel is closed by peer", not a simulated/mocked exception.
+            sempV2Api.action().doMsgVpnClientDisconnect(solaceTestContainer.getVpn(), broker.getUniqueName(), new Object());
+
+            assertDoesNotThrow(() -> broker.publishMessage(
+                            SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_DEFAULT_TOPIC, "{\"test\":\"payload\"}"),
+                    "A transient disconnect within the configured retry budget must not fail the LVQ " +
+                            "publish - see DATAGO-149324 Finding 2");
+        } finally {
+            broker.close();
+        }
+    }
+
+    @Test
+    void publishRetriesWithBackoffThenFailsWhenBudgetExhausted() throws Exception {
+        Map<String, String> properties = propertiesWith(
+                SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRIES, "3",
+                SolaceSparkStreamingProperties.LVQ_PUBLISH_RETRY_INTERVAL, "300",
+                // Deliberately prevent JCSMP's own session from self-healing, so every one of our
+                // retry attempts genuinely fails - isolating our own retry+backoff loop's behavior.
+                SolaceSparkStreamingProperties.SOLACE_RECONNECT_RETRIES, "0"
+        );
+        SolaceBroker broker = new SolaceBroker(properties, "producer");
+        try {
+            broker.createLVQIfNotExist();
+            broker.initProducer();
+
+            sempV2Api.action().doMsgVpnClientDisconnect(solaceTestContainer.getVpn(), broker.getUniqueName(), new Object());
+
+            long start = System.currentTimeMillis();
+            assertThrows(SolaceSessionException.class, () -> broker.publishMessage(
+                    SolaceSparkStreamingProperties.SOLACE_SPARK_CONNECTOR_LVQ_DEFAULT_TOPIC, "{\"test\":\"payload\"}"));
+            long elapsed = System.currentTimeMillis() - start;
+
+            // 3 retries at 300/600/1200ms backoff = >=2100ms before giving up on the 4th attempt.
+            // This is the core regression guard: one failure must NOT fail the query immediately.
+            assertTrue(elapsed >= 2000,
+                    "Expected publishMessage to retry with exponential backoff (>=2000ms elapsed for " +
+                            "3 retries at 300/600/1200ms) before giving up, but only " + elapsed + "ms elapsed " +
+                            "- see DATAGO-149324 Finding 2");
+        } finally {
+            broker.close();
+        }
+    }
+}

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceBrokerQueueBrowserIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceBrokerQueueBrowserIT.java
@@ -1,0 +1,183 @@
+package com.solacecoe.connectors.spark;
+
+import com.solace.semp.v2.config.client.model.MsgVpnQueue;
+import com.solace.semp.v2.monitor.client.model.MsgVpnQueueTxFlowsResponse;
+import com.solacecoe.connectors.spark.base.SempV2Api;
+import com.solacecoe.connectors.spark.base.SolaceSession;
+import com.solacecoe.connectors.spark.containers.SolaceTestContainer;
+import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkStreamingProperties;
+import com.solacecoe.connectors.spark.streaming.solace.SolaceBroker;
+import com.solacesystems.jcsmp.DeliveryMode;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
+import com.solacesystems.jcsmp.Queue;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.solace.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DATAGO-149324 Finding 4: SolaceBroker.isQueueFull()/browseLVQ() created and destroyed a Browser
+ * (a broker-side flow) on every micro-batch, and used the no-arg Browser.getNext() which - per
+ * Solace Support's independent reproduction - could block the driver's offset thread for 80+ minutes
+ * instead of honouring the configured wait timeout.
+ *
+ * The fix: getNext(timeout) is called explicitly, the wait timeout / retry count are configurable
+ * (queueFullCheckWaitTimeoutInMillis / queueFullCheckRetries), and the Browser is reused across
+ * micro-batches by default (reuseBrowserConnections, opt-out available for flow-constrained brokers).
+ *
+ * Runs against a real Solace broker. Flow reuse is verified via the SEMP monitor API - the same
+ * getMsgVpnQueueTxFlows call already used elsewhere in this test suite - rather than by inference.
+ */
+@Testcontainers
+class SolaceBrokerQueueBrowserIT {
+    private static SolaceTestContainer solaceTestContainer;
+    private static SempV2Api sempV2Api;
+    private static Map<String, String> baseProperties;
+    private static final String QUEUE_NAME = "queue-browser-reuse-test-queue";
+
+    @BeforeAll
+    static void setup() throws Exception {
+        solaceTestContainer = new SolaceTestContainer("solace/solace-pubsub-standard:latest", Collections.emptyMap());
+        solaceTestContainer.start();
+        sempV2Api = new SempV2Api(String.format("http://%s:%d", solaceTestContainer.getHost(), solaceTestContainer.getMappedPort(8080)), "admin", "admin");
+
+        MsgVpnQueue queue = new MsgVpnQueue();
+        queue.queueName(QUEUE_NAME);
+        queue.accessType(MsgVpnQueue.AccessTypeEnum.NON_EXCLUSIVE);
+        queue.permission(MsgVpnQueue.PermissionEnum.DELETE);
+        queue.ingressEnabled(true);
+        queue.egressEnabled(true);
+        sempV2Api.config().createMsgVpnQueue("default", queue, null, null);
+
+        baseProperties = new HashMap<>();
+        baseProperties.put(SolaceSparkStreamingProperties.HOST, solaceTestContainer.getOrigin(Service.SMF));
+        baseProperties.put(SolaceSparkStreamingProperties.VPN, solaceTestContainer.getVpn());
+        baseProperties.put(SolaceSparkStreamingProperties.USERNAME, solaceTestContainer.getUsername());
+        baseProperties.put(SolaceSparkStreamingProperties.PASSWORD, solaceTestContainer.getPassword());
+        baseProperties.put(SolaceSparkStreamingProperties.QUEUE, QUEUE_NAME);
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (solaceTestContainer != null) {
+            solaceTestContainer.stop();
+        }
+    }
+
+    private Map<String, String> propertiesWith(String... kv) {
+        Map<String, String> props = new HashMap<>(baseProperties);
+        for (int i = 0; i < kv.length; i += 2) {
+            props.put(kv[i], kv[i + 1]);
+        }
+        return props;
+    }
+
+    private void publishToQueue(String body) throws Exception {
+        SolaceSession session = new SolaceSession(solaceTestContainer.getOrigin(Service.SMF), solaceTestContainer.getVpn(), solaceTestContainer.getUsername(), solaceTestContainer.getPassword());
+        XMLMessageProducer producer = session.getSession().getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+            @Override public void responseReceivedEx(Object o) { }
+            @Override public void handleErrorEx(Object o, com.solacesystems.jcsmp.JCSMPException e, long l) { }
+        });
+        com.solacesystems.jcsmp.BytesXMLMessage msg = JCSMPFactory.onlyInstance().createMessage(com.solacesystems.jcsmp.BytesXMLMessage.class);
+        msg.writeBytes(body.getBytes(StandardCharsets.UTF_8));
+        msg.setDeliveryMode(DeliveryMode.PERSISTENT);
+        Queue queue = JCSMPFactory.onlyInstance().createQueue(QUEUE_NAME);
+        producer.send(msg, queue);
+        Thread.sleep(500); // let it land before browsing
+        producer.close();
+        session.getSession().closeSession();
+    }
+
+    @Test
+    void reusedBrowserKeepsExactlyOneStandingFlowAcrossManyPolls() throws Exception {
+        Map<String, String> properties = propertiesWith(
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_WAIT_TIMEOUT, "300",
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_RETRIES, "1",
+                SolaceSparkStreamingProperties.REUSE_BROWSER_CONNECTIONS, "true"
+        );
+        SolaceBroker broker = new SolaceBroker(properties, "monitoring-consumer");
+        try {
+            for (int i = 0; i < 5; i++) {
+                broker.isQueueFull(); // queue is empty - each call is bounded by the configured timeout
+            }
+
+            MsgVpnQueueTxFlowsResponse flows = sempV2Api.monitor().getMsgVpnQueueTxFlows("default", QUEUE_NAME, 10, null, null, null);
+            int flowCount = flows.getData() == null ? 0 : flows.getData().size();
+            assertEquals(1, flowCount,
+                    "Expected exactly 1 standing egress flow on the queue after 5 polls with " +
+                            "reuseBrowserConnections=true (one Browser reused across calls), but found " +
+                            flowCount + " - see DATAGO-149324 Finding 4");
+        } finally {
+            broker.close();
+        }
+    }
+
+    @Test
+    void nonReusedBrowserLeavesNoStandingFlowBetweenPolls() throws Exception {
+        Map<String, String> properties = propertiesWith(
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_WAIT_TIMEOUT, "300",
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_RETRIES, "1",
+                SolaceSparkStreamingProperties.REUSE_BROWSER_CONNECTIONS, "false"
+        );
+        SolaceBroker broker = new SolaceBroker(properties, "monitoring-consumer");
+        try {
+            broker.isQueueFull();
+
+            MsgVpnQueueTxFlowsResponse flows = sempV2Api.monitor().getMsgVpnQueueTxFlows("default", QUEUE_NAME, 10, null, null, null);
+            int flowCount = flows.getData() == null ? 0 : flows.getData().size();
+            assertEquals(0, flowCount,
+                    "Expected no standing flow between polls when reuseBrowserConnections=false " +
+                            "(each poll should provision and tear down its own Browser), but found " +
+                            flowCount + " - see DATAGO-149324 Finding 4");
+        } finally {
+            broker.close();
+        }
+    }
+
+    @Test
+    void isQueueFullReturnsBoundedRegardlessOfConfiguredRetries() throws Exception {
+        // This is the direct regression guard for the confirmed root cause of the 80+ minute hang:
+        // getNext(timeout) must actually bound the wait, honouring the configured retry count, rather
+        // than blocking indefinitely on the no-arg getNext().
+        Map<String, String> properties = propertiesWith(
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_WAIT_TIMEOUT, "500",
+                SolaceSparkStreamingProperties.QUEUE_FULL_CHECK_RETRIES, "3"
+        );
+        SolaceBroker broker = new SolaceBroker(properties, "monitoring-consumer");
+        try {
+            long start = System.currentTimeMillis();
+            boolean full = broker.isQueueFull();
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertFalse(full, "Queue is empty at this point in the test - isQueueFull() should return false");
+            // 3 attempts x 500ms = 1500ms upper bound, with generous headroom for scheduling jitter.
+            assertTrue(elapsed < 5000,
+                    "isQueueFull() took " + elapsed + "ms on an empty queue with " +
+                            "queueFullCheckRetries=3/queueFullCheckWaitTimeoutInMillis=500 (expected <5000ms) " +
+                            "- indicates the bounded getNext(timeout) fix regressed - see DATAGO-149324 Finding 4");
+        } finally {
+            broker.close();
+        }
+
+        // Now prove it correctly detects a genuinely full queue too, not just "always returns false fast".
+        publishToQueue("hello");
+        SolaceBroker broker2 = new SolaceBroker(properties, "monitoring-consumer");
+        try {
+            assertTrue(broker2.isQueueFull(), "isQueueFull() should return true once a message is available");
+        } finally {
+            broker2.close();
+        }
+    }
+}

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
@@ -10,6 +10,7 @@ import com.solace.semp.v2.monitor.client.model.MsgVpnClientsResponse;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -23,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * DATAGO-149324 Finding 3: SolaceDataWriter previously constructed a brand-new SolaceBroker (a full
@@ -102,5 +105,36 @@ class SolaceDataWriterSessionReuseIT {
                 "Expected exactly 1 underlying producer connection after " + MICRO_BATCHES +
                         " simulated micro-batches for the same partition (session reuse), but found " +
                         connectedProducerClients + " - see DATAGO-149324 Finding 3");
+    }
+
+    /**
+     * commit() waits on a CompletableFuture that is only ever completed from
+     * responseReceivedEx() - which fires once per actual publish ack. When a partition receives no
+     * rows in a given micro-batch (a normal, common occurrence in streaming - e.g. an idle source
+     * partition), publishedMessages stays 0 and that future would never complete, so commit() would
+     * block for the full publishAckTimeout waiting for acknowledgements that were never going to
+     * arrive, then either fail the batch or log a spurious timeout warning every single empty batch.
+     */
+    @Test
+    void commitReturnsImmediatelyForAnEmptyBatch() throws Exception {
+        StructType schema = new StructType(SolaceSparkSchemaProperties.structFields(false));
+        Map<String, String> propertiesWithLongTimeout = new HashMap<>(properties);
+        // Deliberately long, so a passing test proves commit() didn't wait at all - a bug here
+        // would make this test take at least this long, not just eventually still pass.
+        propertiesWithLongTimeout.put(SolaceSparkStreamingProperties.PUBLISH_ACK_TIMEOUT, "8000");
+        SolaceStreamingDataWriterFactory factory = new SolaceStreamingDataWriterFactory(schema, propertiesWithLongTimeout, new CaseInsensitiveStringMap(Collections.emptyMap()));
+
+        // A distinct partitionId, isolated from the other test's cached connection/assertions.
+        DataWriter<InternalRow> writer = factory.createWriter(1, 0, 0);
+        long start = System.currentTimeMillis();
+        WriterCommitMessage result = writer.commit(); // no write() call at all - zero rows this batch
+        long elapsed = System.currentTimeMillis() - start;
+        writer.close();
+
+        assertNotNull(result, "commit() on an empty batch must still return a commit message, not throw");
+        assertTrue(elapsed < 2000,
+                "commit() on an empty batch took " + elapsed + "ms (publishAckTimeout was 8000ms) - " +
+                        "it should return immediately since there is nothing to acknowledge, not block " +
+                        "waiting for an ack that was never going to arrive");
     }
 }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
@@ -1,0 +1,109 @@
+package com.solacecoe.connectors.spark;
+
+import com.solacecoe.connectors.spark.base.SempV2Api;
+import com.solacecoe.connectors.spark.containers.SolaceTestContainer;
+import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkSchemaProperties;
+import com.solacecoe.connectors.spark.streaming.properties.SolaceSparkStreamingProperties;
+import com.solacecoe.connectors.spark.streaming.write.SolaceDataWriter;
+import com.solacecoe.connectors.spark.streaming.write.SolaceStreamingDataWriterFactory;
+import com.solace.semp.v2.monitor.client.model.MsgVpnClientsResponse;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.solace.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * DATAGO-149324 Finding 3: SolaceDataWriter previously constructed a brand-new SolaceBroker (a full
+ * JCSMP session - DNS resolution, TLS handshake) in its constructor, and Spark calls
+ * DataWriterFactory.createWriter() once per partition per micro-batch. A 10s-trigger streaming job
+ * opened/closed thousands of sessions per day, and a single transient DNS blip failed the write task.
+ *
+ * The fix caches the producer session per partition (via SolaceConnectionManager, the same mechanism
+ * already used for consumer connections) and reuses it across micro-batches instead of rebuilding it
+ * every trigger.
+ *
+ * This test runs against a real Solace broker and drives the actual SolaceStreamingDataWriterFactory /
+ * SolaceDataWriter classes exactly as Spark would across several simulated micro-batches for the same
+ * partition, then asserts via the SEMP monitor API that only ONE underlying client connection was ever
+ * established - not one per micro-batch.
+ */
+@Testcontainers
+class SolaceDataWriterSessionReuseIT {
+    private static SolaceTestContainer solaceTestContainer;
+    private static SempV2Api sempV2Api;
+    private static Map<String, String> properties;
+    private static final int PARTITION_ID = 0;
+    private static final int MICRO_BATCHES = 5;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        solaceTestContainer = new SolaceTestContainer("solace/solace-pubsub-standard:latest", Collections.emptyMap());
+        solaceTestContainer.start();
+        sempV2Api = new SempV2Api(String.format("http://%s:%d", solaceTestContainer.getHost(), solaceTestContainer.getMappedPort(8080)), "admin", "admin");
+
+        properties = new HashMap<>();
+        properties.put(SolaceSparkStreamingProperties.HOST, solaceTestContainer.getOrigin(Service.SMF));
+        properties.put(SolaceSparkStreamingProperties.VPN, solaceTestContainer.getVpn());
+        properties.put(SolaceSparkStreamingProperties.USERNAME, solaceTestContainer.getUsername());
+        properties.put(SolaceSparkStreamingProperties.PASSWORD, solaceTestContainer.getPassword());
+        properties.put(SolaceSparkStreamingProperties.TOPIC, "solace/spark/streaming/writer-reuse-test");
+        properties.put(SolaceSparkStreamingProperties.PUBLISH_ACK_TIMEOUT, "5000");
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (solaceTestContainer != null) {
+            solaceTestContainer.stop();
+        }
+    }
+
+    private InternalRow row(String id) {
+        return new GenericInternalRow(new Object[]{
+                UTF8String.fromString(id),
+                "hello".getBytes(StandardCharsets.UTF_8),
+                UTF8String.fromString(""),
+                null, // topic column null - hasDefaultTopic covers it via properties.TOPIC
+                System.currentTimeMillis() * 1000L
+        });
+    }
+
+    @Test
+    void producerSessionIsReusedAcrossMicroBatchesForTheSamePartition() throws Exception {
+        StructType schema = new StructType(SolaceSparkSchemaProperties.structFields(false));
+        SolaceStreamingDataWriterFactory factory = new SolaceStreamingDataWriterFactory(schema, properties, new CaseInsensitiveStringMap(Collections.emptyMap()));
+
+        for (int batch = 0; batch < MICRO_BATCHES; batch++) {
+            // Exactly what Spark does once per partition, per micro-batch, per epoch.
+            DataWriter<InternalRow> writer = factory.createWriter(PARTITION_ID, batch, batch);
+            writer.write(row("msg-" + batch));
+            writer.commit();
+            writer.close();
+        }
+
+        MsgVpnClientsResponse response = sempV2Api.monitor().getMsgVpnClients(
+                solaceTestContainer.getVpn(), 100, null,
+                List.of("clientUsername==" + solaceTestContainer.getUsername(), "clientName==*producer*"),
+                null);
+
+        int connectedProducerClients = response.getData() == null ? 0 : response.getData().size();
+        assertEquals(1, connectedProducerClients,
+                "Expected exactly 1 underlying producer connection after " + MICRO_BATCHES +
+                        " simulated micro-batches for the same partition (session reuse), but found " +
+                        connectedProducerClients + " - see DATAGO-149324 Finding 3");
+    }
+}

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceDataWriterSessionReuseIT.java
@@ -20,10 +20,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.solace.Service;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -97,7 +94,7 @@ class SolaceDataWriterSessionReuseIT {
 
         MsgVpnClientsResponse response = sempV2Api.monitor().getMsgVpnClients(
                 solaceTestContainer.getVpn(), 100, null,
-                List.of("clientUsername==" + solaceTestContainer.getUsername(), "clientName==*producer*"),
+                Arrays.asList("clientUsername==" + solaceTestContainer.getUsername(), "clientName==*producer*"),
                 null);
 
         int connectedProducerClients = response.getData() == null ? 0 : response.getData().size();

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceMicroBatchMemoryLeakTest.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceMicroBatchMemoryLeakTest.java
@@ -1,0 +1,36 @@
+package com.solacecoe.connectors.spark;
+
+import com.solacecoe.connectors.spark.streaming.SolaceMicroBatch;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * DATAGO-149324 Finding 1: SolaceMicroBatch.lastKnownMessageIds accumulated one checkpoint message
+ * id per micro-batch trigger, onto a single String field, for the entire lifetime of the query, via
+ * String.join - and was never read anywhere in the codebase. Once the accumulated string crossed the
+ * G1 humongous-allocation threshold, every subsequent trigger allocated a full copy of it, causing
+ * unbounded driver memory growth. The field and its 3 append call-sites were deleted entirely since
+ * deletion is behavior-neutral (confirmed: no code path ever reads lastKnownMessageIds).
+ *
+ * This is a plain unit test (no broker/container required) that guards against the field being
+ * reintroduced by a future change.
+ */
+class SolaceMicroBatchMemoryLeakTest {
+    @Test
+    void lastKnownMessageIdsFieldMustNotBeReintroduced() {
+        boolean fieldExists = Arrays.stream(SolaceMicroBatch.class.getDeclaredFields())
+                .map(Field::getName)
+                .anyMatch("lastKnownMessageIds"::equals);
+
+        assertFalse(fieldExists,
+                "SolaceMicroBatch.lastKnownMessageIds must not exist - see DATAGO-149324 Finding 1. " +
+                        "This field is never read anywhere and previously caused unbounded driver memory " +
+                        "growth by accumulating one checkpoint message id per micro-batch trigger, forever, " +
+                        "via String.join. If you need to track the last known message id for some new " +
+                        "purpose, bound its size and confirm it is actually read before reintroducing it.");
+    }
+}

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -600,7 +600,7 @@ public class SolaceSparkStreamingSinkIT {
             throw new RuntimeException(e);
         }
 
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -764,9 +764,6 @@ public class SolaceSparkStreamingSinkIT {
                 @Override
                 public void onReceive(BytesXMLMessage bytesXMLMessage) {
                     count[0] = count[0] + 1;
-                    if(count[0] == 100) {
-                        System.out.println("Total records consumed from Solace " + count[0]);
-                    }
                 }
 
                 @Override
@@ -786,7 +783,8 @@ public class SolaceSparkStreamingSinkIT {
         if (msgVpnQueueTxFlowResponse.getData() != null && !msgVpnQueueTxFlowResponse.getData().isEmpty()) {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
-        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertTrue(count[0] >= 100));
+        System.out.println("Total records consumed from Solace " + count[0]);
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -783,7 +783,7 @@ public class SolaceSparkStreamingSinkIT {
         if (msgVpnQueueTxFlowResponse.getData() != null && !msgVpnQueueTxFlowResponse.getData().isEmpty()) {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
-        Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -784,7 +784,6 @@ public class SolaceSparkStreamingSinkIT {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
         Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertTrue(count[0] >= 100));
-        System.out.println("Total records consumed from Solace " + count[0]);
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -783,7 +783,7 @@ public class SolaceSparkStreamingSinkIT {
         if (msgVpnQueueTxFlowResponse.getData() != null && !msgVpnQueueTxFlowResponse.getData().isEmpty()) {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
-        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertTrue(count[0] >= 100));
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -764,6 +764,9 @@ public class SolaceSparkStreamingSinkIT {
                 @Override
                 public void onReceive(BytesXMLMessage bytesXMLMessage) {
                     count[0] = count[0] + 1;
+                    if(count[0] == 100) {
+                        System.out.println("Total records consumed from Solace " + count[0]);
+                    }
                 }
 
                 @Override
@@ -783,7 +786,7 @@ public class SolaceSparkStreamingSinkIT {
         if (msgVpnQueueTxFlowResponse.getData() != null && !msgVpnQueueTxFlowResponse.getData().isEmpty()) {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
-        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertTrue(count[0] >= 100));
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -783,7 +783,7 @@ public class SolaceSparkStreamingSinkIT {
         if (msgVpnQueueTxFlowResponse.getData() != null && !msgVpnQueueTxFlowResponse.getData().isEmpty()) {
             assertEquals(3, msgVpnQueueTxFlowResponse.getData().size(), "Number of consumer flows should be 3");
         }
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertTrue(count[0] >= 100));
+        Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> Assertions.assertEquals(100, count[0]));
         messageConsumer.stop();
         messageConsumer.close();
     }

--- a/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
+++ b/src/test/java/com/solacecoe/connectors/spark/SolaceSparkStreamingSinkIT.java
@@ -507,7 +507,7 @@ public class SolaceSparkStreamingSinkIT {
             throw new RuntimeException(e);
         }
 
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> count[0] == 100);
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).until(() -> count[0] == 100);
         Assertions.assertEquals(1, messageHeader[0], "Message Priority mismatch");
         messageConsumer.stop();
         messageConsumer.close();
@@ -555,7 +555,7 @@ public class SolaceSparkStreamingSinkIT {
             throw new RuntimeException(e);
         }
 
-        Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> count[0] == 100);
+        Awaitility.await().atMost(90, TimeUnit.SECONDS).until(() -> count[0] == 100);
         Assertions.assertEquals(4, messageHeader[0], "Message Priority mismatch");
         messageConsumer.stop();
         messageConsumer.close();


### PR DESCRIPTION
Finding 1 (Critical): Remove lastKnownMessageIds from SolaceMicroBatch.java, or bound it to the current batch only. The field is never read — deletion is behaviour-neutral. Backport to 3.1.x is required; the customer cannot take a JDK 11 / Spark 4 migration.

Finding 2 (High): Add reconnect and retry with backoff around the LVQ publish in SolaceMicroBatch.commit() so a transport disconnect does not terminate the query.

Finding 3 (High): Reuse the producer JCSMP session across micro-batches. Retry session creation with backoff on transient DNS failure.

Finding 4 (Medium): Avoid creating two Browser flows per micro-batch. Make isQueueFull() poll non-blocking or configurable. Fix the indefinite block when setWaitTimeout is not honoured on an empty queue.